### PR TITLE
Adding info about cXensebot

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -577,5 +577,11 @@
     "pattern": "Twitterbot",
     "addition_date": "2014/09/12",
     "instances": ["Twitterbot/0.1", "Twitterbot/1.0" ]
+  },
+  {
+    "pattern": "cXensebot",
+    "addition_date": "2014/10/05",
+    "instances": ["cXensebot/1.1a"],
+    "url": "http://www.cxense.com/bot.html"
   }
 ]


### PR DESCRIPTION
The url is the one found in the user-agent but it leads to a 404-page
at cxense.com
