### PR TITLE
adds Applebot and TweetmemeBot

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -686,5 +686,16 @@
     "url": "http://www.archive.org/details/archive.org_bot",
     "instances": ["Mozilla/5.0 (compatible; archive.org_bot +http://www.archive.org/details/archive.org_bot)"],
     "addition_date": "2015/04/14"
+  },
+  {
+    "pattern": "Applebot",
+    "url": "http://www.apple.com/go/applebot",
+    "addition_date": "2015/04/15"
+  },
+  {
+    "pattern": "TweetmemeBot",
+    "url": "http://datasift.com/bot.html",
+    "instances": ["Mozilla/5.0 (TweetmemeBot/4.0; +http://datasift.com/bot.html) Gecko/20100101 Firefox/31.0"],
+    "addition_date": "2015/04/15"
   }
 ]


### PR DESCRIPTION
I got those bots in our records:

Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1; +http://www.apple.com/go/applebot)
I haven't put instances for Applebot because it's very variable.

Mozilla/5.0 (TweetmemeBot/4.0; +http://datasift.com/bot.html) Gecko/20100101 Firefox/31.0