### PR TITLE
Update README.md with instructions to produce a single RegExp rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,21 @@ The list is under a [CC-SA](http://creativecommons.org/licenses/by-sa/3.0/) lice
 
 --Martin
 
+## Create a single RegExp rule for matching crawlers
+1. Open your browser console
+2. Run
+
+    var botPattern, botRegexp, xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function(evt){var xhr = evt.target; if (xhr.readyState==4 && xhr.status==200) {
+        var bots = JSON.parse(xhr.responseText);
+        botPattern="(";bots.forEach(function(item){botPattern+=item.pattern+'|';});
+        botPattern=botPattern.substring(0,botPattern.length-1)+')';
+        console.info("The botPattern is %o", botPattern);
+        console.log('You can type "botPattern" to show crawler-matching pattern again');
+        botRegexp = new RegExp(botPattern, 'i'); // match case insensitive
+        console.log('You can use botRegexp to test User-Agent string. Like this:\n\nbotRegexp.test(\'Googlebot/2.1 (+http://www.googlebot.com/bot.html)\')');
+    }};
+    xhr.open('GET', 'https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json', true);
+    xhr.send();
+3. Use botPattern to create new RegExp(botPattern, 'i') instance to .test() against the User-Agent string;
+

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ The list is under a [CC-SA](http://creativecommons.org/licenses/by-sa/3.0/) lice
 1. Open your browser console
 2. Run
 
-    var botPattern, botRegexp, xhr = new XMLHttpRequest();
-    xhr.onreadystatechange = function(evt){var xhr = evt.target; if (xhr.readyState==4 && xhr.status==200) {
-        var bots = JSON.parse(xhr.responseText);
-        botPattern="(";bots.forEach(function(item){botPattern+=item.pattern+'|';});
-        botPattern=botPattern.substring(0,botPattern.length-1)+')';
-        console.info("The botPattern is %o", botPattern);
-        console.log('You can type "botPattern" to show crawler-matching pattern again');
-        botRegexp = new RegExp(botPattern, 'i'); // match case insensitive
-        console.log('You can use botRegexp to test User-Agent string. Like this:\n\nbotRegexp.test(\'Googlebot/2.1 (+http://www.googlebot.com/bot.html)\')');
-    }};
-    xhr.open('GET', 'https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json', true);
-    xhr.send();
+        var botPattern, botRegexp, xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function(evt){var xhr = evt.target; if (xhr.readyState==4 && xhr.status==200) {
+            var bots = JSON.parse(xhr.responseText);
+            botPattern="(";bots.forEach(function(item){botPattern+=item.pattern+'|';});
+            botPattern=botPattern.substring(0,botPattern.length-1)+')';
+            console.info("The botPattern is %o", botPattern);
+            console.log('You can type "botPattern" to show crawler-matching pattern again');
+            botRegexp = new RegExp(botPattern, 'i'); // match case insensitive
+            console.log('You can use botRegexp to test User-Agent string. Like this:\n\nbotRegexp.test(\'Googlebot/2.1 (+http://www.googlebot.com/bot.html)\')');
+        }};
+        xhr.open('GET', 'https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json', true);
+        xhr.send();
 3. Use botPattern to create new RegExp(botPattern, 'i') instance to .test() against the User-Agent string;
 

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -8,7 +8,10 @@
   }, 
   {
     "pattern": "Googlebot-Image"
-  }, 
+  },
+  {
+    "pattern": "Google favicon"
+  },
   {
     "pattern": "Mediapartners-Google", 
     "url": "https://support.google.com/webmasters/answer/1061943?hl=en"


### PR DESCRIPTION
Sometimes we may need to have one regexp rule to test if the user-agent a crawler or not. I described a way to do this easily.
Also merged a change by @gunesahmet with `Google favicon` crawler