### PR TITLE
Remove Voyager bot

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -207,11 +207,6 @@
     "url": "http://www.linguee.com/bot"
   },
   {
-    "pattern": "Voyager",
-    "addition_date": "2010/02/01",
-    "url": "http://www.kosmix.com/crawler.html"
-  },
-  {
     "pattern": "CyberPatrol",
     "addition_date": "2010/02/11",
     "url": "http://www.cyberpatrol.com/cyberpatrolcrawler.asp"


### PR DESCRIPTION
According to https://udger.com/resources/ua-list/bot-detail?bot=voyager,
this bot has been inactive for quite some time. Kosmix was acquired by
walmartlabs.

See issue #35 