### PR TITLE
Add package.json to allow installing directly from GitHub

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Martin Monperrus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "name": "crawler-user-agents",
+  "version": "1.0.0",
+  "author": "Martin Monperrus <martin.monperrus@univ-lille1.fr>",
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "name": "crawler-user-agents",
   "version": "1.0.0",
-  "author": "Martin Monperrus <martin.monperrus@univ-lille1.fr>",
+  "author": "Martin Monperrus <martin.monperrus@gnieh.org>",
   "license": "MIT"
 }


### PR DESCRIPTION
To be clear: this is not supposed to be published to npm or other registries, as the author has previously mentioned to not be willing to publish and maintain a package in the registry. [[1]](https://github.com/monperrus/crawler-user-agents/issues/14#issuecomment-175269246)

Instead, by simply adding a `package.json` file to the repository, it will allow consumers to install the package directly from GitHub through yarn/npm. For instance:

```
yarn add "https://github.com/monperrus/crawler-user-agents.git#d5ee77dad02fed5d391bb3295355932a9f154071"
# OR
npm install "https://github.com/monperrus/crawler-user-agents.git#d5ee77dad02fed5d391bb3295355932a9f154071"
```

This will not require any future changes from the maintainers, the `package.json` is marked with the `private` flag to prevent publishing to the registry. Users then should explicitly upgrade and review the changes.

I believe this is a good compromise and a viable approach for users, and this does not require further maintainance work.