### PR TITLE
Validate.py: case insensitive duplicate check

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -127,7 +127,8 @@
   {
     "pattern": "[wW]get",
     "instances": [
-      "WGETbot/1.0 (+http://wget.alanreed.org)"
+      "WGETbot/1.0 (+http://wget.alanreed.org)",
+      "Wget/1.14 (linux-gnu)"
     ]
   },
   {
@@ -568,7 +569,9 @@
     "pattern": "Baiduspider",
     "addition_date": "2010/07/15",
     "url": "http://www.baidu.jp/spider/",
-    "instances": []
+    "instances": [
+      "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)"
+    ]
   },
   {
     "pattern": "citeseerxbot",
@@ -781,7 +784,9 @@
   {
     "pattern": "AhrefsBot",
     "addition_date": "2011/08/28",
-    "instances": []
+    "instances": [
+      "Mozilla/5.0 (compatible; AhrefsBot/5.2; News; +http://ahrefs.com/robot/)"
+    ]
   },
   {
     "pattern": "Aboundex",
@@ -795,7 +800,9 @@
   {
     "pattern": "domaincrawler",
     "addition_date": "2011/10/21",
-    "instances": []
+    "instances": [
+      "CipaCrawler/3.0 (info@domaincrawler.com; http://www.domaincrawler.com/www.example.com)"
+    ]
   },
   {
     "pattern": "wbsearchbot",
@@ -815,7 +822,9 @@
     "pattern": "CCBot",
     "addition_date": "2012/02/05",
     "url": "http://www.commoncrawl.org/bot.html",
-    "instances": []
+    "instances": [
+      "CCBot/2.0 (http://commoncrawl.org/faq/)"
+    ]
   },
   {
     "pattern": "edisterbot",
@@ -1691,7 +1700,9 @@
     "pattern": "redditbot",
     "addition_date": "2016/11/03",
     "url": "http://www.reddit.com/feedback",
-    "instances": []
+    "instances": [
+      "Mozilla/5.0 (compatible; redditbot/1.0; +http://www.reddit.com/feedback)"
+    ]
   },
   {
     "pattern": "datagnionbot",
@@ -1915,129 +1926,210 @@
   {
     "pattern": "Discordbot",
     "addition_date": "2017/09/22",
-    "url": "https://discordapp.com"
+    "url": "https://discordapp.com",
+    "instances": [
+      "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
+    ]
   },
   {
     "pattern": "TelegramBot",
-    "addition_date": "2017/10/01"
+    "addition_date": "2017/10/01",
+    "instances": [
+      "TelegramBot (like TwitterBot)"
+    ]
   },
   {
     "pattern": "InfoPath.2",
-    "addition_date": "2017/10/07"
+    "addition_date": "2017/10/07",
+    "instances": [
+      "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; InfoPath.2)"
+    ]
   },
   {
     "pattern": "Jetslide",
     "addition_date": "2017/09/27",
-    "url": "http://jetsli.de/crawler"
+    "url": "http://jetsli.de/crawler",
+    "instances": [
+      "Mozilla/5.0 (compatible; Jetslide; +http://jetsli.de/crawler)"
+    ]
   },
   {
     "pattern": "newsharecounts",
     "addition_date": "2017/09/30",
-    "url": "http://newsharecounts.com/crawler"
+    "url": "http://newsharecounts.com/crawler",
+    "instances": [
+      "Mozilla/5.0 (compatible; NewShareCounts.com/1.0; +http://newsharecounts.com/crawler)"
+    ]
   },
   {
     "pattern": "James BOT",
     "addition_date": "2017/10/12",
-    "url": "http://cognitiveseo.com/bot.html"
+    "url": "http://cognitiveseo.com/bot.html",
+    "instances": [
+      "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.6) Gecko/20070725 Firefox/2.0.0.6 - James BOT - WebCrawler http://cognitiveseo.com/bot.html"
+    ]
   },
   {
     "pattern": "Barkrowler",
     "addition_date": "2017/10/09",
-    "url": "http://www.exensa.com/crawl"
+    "url": "http://www.exensa.com/crawl",
+    "instances": [
+      "Barkrowler/0.5.1 (experimenting / debugging - sorry for your logs ) http://www.exensa.com/crawl - admin@exensa.com -- based on BuBiNG"
+    ]
   },
   {
     "pattern": "TinEye-bot",
     "addition_date": "2017/10/14",
-    "url": "http://www.tineye.com/crawler.html"
+    "url": "http://www.tineye.com/crawler.html",
+    "instances": [
+      "Mozilla/5.0 (compatible; TinEye-bot/1.31; +http://www.tineye.com/crawler.html)"
+    ]
   },
   {
     "pattern": "SocialRankIOBot",
     "addition_date": "2017/10/19",
-    "url": "http://socialrank.io/about"
+    "url": "http://socialrank.io/about",
+    "instances": [
+      "SocialRankIOBot; http://socialrank.io/about"
+    ]
   },
   {
     "pattern": "trendictionbot",
     "addition_date": "2017/10/30",
-    "url": "http://www.trendiction.de/bot"
+    "url": "http://www.trendiction.de/bot",
+    "instances": [
+      "Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.0; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20071127 Firefox/3.0.0.11"
+    ]
   },
   {
     "pattern": "Ocarinabot",
-    "addition_date": "2017/09/27"
+    "addition_date": "2017/09/27",
+    "instances": [
+      "Ocarinabot"
+    ]
   },
   {
     "pattern": "epicbot",
     "addition_date": "2017/10/31",
-    "url": "http://www.epictions.com/epicbot"
+    "url": "http://www.epictions.com/epicbot",
+    "instances": [
+      "Mozilla/5.0 (compatible; epicbot; +http://www.epictions.com/epicbot)"
+    ]
   },
   {
     "pattern": "Primalbot",
     "addition_date": "2017/09/27",
-    "url": "https://www.primal.com"
+    "url": "https://www.primal.com",
+    "instances": [
+      "Mozilla/5.0 (compatible; Primalbot; +https://www.primal.com;)"
+    ]
   },
   {
     "pattern": "DuckDuckGo-Favicons-Bot",
     "addition_date": "2017/10/06",
-    "url": "http://duckduckgo.com"
+    "url": "http://duckduckgo.com",
+    "instances": [
+      "Mozilla/5.0 (compatible; DuckDuckGo-Favicons-Bot/1.0; +http://duckduckgo.com)"
+    ]
   },
   {
     "pattern": "GnowitNewsbot",
     "addition_date": "2017/10/30",
-    "url": "http://www.gnowit.com"
+    "url": "http://www.gnowit.com",
+    "instances": [
+      "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0 / GnowitNewsbot / Contact information at http://www.gnowit.com"
+    ]
   },
   {
     "pattern": "Leikibot",
     "addition_date": "2017/09/24",
-    "url": "http://www.leiki.com"
+    "url": "http://www.leiki.com",
+    "instances": [
+      "Mozilla/5.0 (Windows NT 6.3;compatible; Leikibot/1.0; +http://www.leiki.com)"
+    ]
   },
   {
     "pattern": "LinkArchiver",
-    "addition_date": "2017/09/24"
+    "addition_date": "2017/09/24",
+    "instances": [
+      "@LinkArchiver twitter bot"
+    ]
   },
   {
     "pattern": "YaK",
     "addition_date": "2017/09/25",
-    "url": "http://linkfluence.com"
+    "url": "http://linkfluence.com",
+    "instances": [
+      "Mozilla/5.0 (compatible; YaK/1.0; http://linkfluence.com/; bot@linkfluence.com)"
+    ]
   },
   {
     "pattern": "PaperLiBot",
     "addition_date": "2017/09/25",
-    "url": "http://support.paper.li/entries/20023257-what-is-paper-li"
+    "url": "http://support.paper.li/entries/20023257-what-is-paper-li",
+    "instances": [
+      "Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)"
+    ]
   },
   {
     "pattern": "Digg Deeper",
     "addition_date": "2017/09/26",
-    "url": "http://digg.com/about"
+    "url": "http://digg.com/about",
+    "instances": [
+      "Digg Deeper/v1 (http://digg.com/about)"
+    ]
   },
   {
     "pattern": "dcrawl",
-    "addition_date": "2017/09/22"
+    "addition_date": "2017/09/22",
+    "instances": [
+      "dcrawl/1.0"
+    ]
   },
   {
     "pattern": "Snacktory",
     "addition_date": "2017/09/23",
-    "url": "https://github.com/karussell/snacktory"
+    "url": "https://github.com/karussell/snacktory",
+    "instances": [
+      "Mozilla/5.0 (compatible; Snacktory; +https://github.com/karussell/snacktory)"
+    ]
   },
   {
     "pattern": "AndersPinkBot",
     "addition_date": "2017/09/24",
-    "url": "http://anderspink.com/bot.html"
+    "url": "http://anderspink.com/bot.html",
+    "instances": [
+      "Mozilla/5.0 (compatible; AndersPinkBot/1.0; +http://anderspink.com/bot.html)"
+    ]
   },
   {
     "pattern": "Fyrebot",
-    "addition_date": "2017/09/22"
+    "addition_date": "2017/09/22",
+    "instances": [
+      "Fyrebot/1.0"
+  ]
   },
   {
     "pattern": "EveryoneSocialBot",
     "addition_date": "2017/09/22",
-    "url": "http://everyonesocial.com"
+    "url": "http://everyonesocial.com",
+    "instances": [
+      "Mozilla/5.0 (compatible; EveryoneSocialBot/1.0; support@everyonesocial.com http://everyonesocial.com/)"
+    ]
   },
   {
     "pattern": "Mediatoolkitbot",
     "addition_date": "2017/10/06",
-    "url": "http://mediatoolkit.com"
+    "url": "http://mediatoolkit.com",
+    "instances": [
+      "Mediatoolkitbot (complaints@mediatoolkit.com)"
+    ]
   },
   {
     "pattern": "Luminator-robots",
-    "addition_date": "2017/09/22"
+    "addition_date": "2017/09/22",
+    "instances": [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.13 (KHTML, like Gecko) Chrome/30.0.1599.66 Safari/537.13 Luminator-robots/2.0"
+    ]
   }
 ]

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -812,7 +812,7 @@
     ]
   },
   {
-    "pattern": "ccbot",
+    "pattern": "CCBot",
     "addition_date": "2012/02/05",
     "url": "http://www.commoncrawl.org/bot.html",
     "instances": []
@@ -865,9 +865,12 @@
     ]
   },
   {
-    "pattern": "yeti",
+    "pattern": "Yeti",
     "addition_date": "2012/05/07",
-    "instances": []
+    "url": "http://naver.me/bot",
+    "instances": [
+      "Mozilla/5.0 (compatible; Yeti/1.1; +http://naver.me/bot)"
+    ]
   },
   {
     "pattern": "RetrevoPageAnalyzer",
@@ -1400,10 +1403,11 @@
     "addition_date": "2015/05/07"
   },
   {
-    "pattern": "SemrushBot",
+    "pattern": "S[eE][mM]rushBot",
     "url": "http://www.semrush.com/bot.html",
     "instances": [
-      "Mozilla/5.0 (compatible; SemrushBot/0.98~bl; +http://www.semrush.com/bot.html)"
+      "Mozilla/5.0 (compatible; SemrushBot/0.98~bl; +http://www.semrush.com/bot.html)",
+      "SEMrushBot"
     ],
     "addition_date": "2015/05/26"
   },
@@ -1947,19 +1951,9 @@
     "url": "http://www.tineye.com/crawler.html"
   },
   {
-    "pattern": "CCBot",
-    "addition_date": "2017/10/18",
-    "url": "http://commoncrawl.org/faq/"
-  },
-  {
     "pattern": "SocialRankIOBot",
     "addition_date": "2017/10/19",
     "url": "http://socialrank.io/about"
-  },
-  {
-    "pattern": "Yeti",
-    "addition_date": "2017/09/26",
-    "url": "http://naver.me/bot"
   },
   {
     "pattern": "trendictionbot",
@@ -1974,10 +1968,6 @@
     "pattern": "epicbot",
     "addition_date": "2017/10/31",
     "url": "http://www.epictions.com/epicbot"
-  },
-  {
-    "pattern": "SEMrushBot",
-    "addition_date": "2017/09/27"
   },
   {
     "pattern": "Primalbot",

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -125,7 +125,7 @@
     ]
   },
   {
-    "pattern": "wget",
+    "pattern": "[wW]get",
     "instances": [
       "WGETbot/1.0 (+http://wget.alanreed.org)"
     ]
@@ -565,7 +565,7 @@
     ]
   },
   {
-    "pattern": "baiduspider",
+    "pattern": "Baiduspider",
     "addition_date": "2010/07/15",
     "url": "http://www.baidu.jp/spider/",
     "instances": []
@@ -779,7 +779,7 @@
     "instances": []
   },
   {
-    "pattern": "ahrefsbot",
+    "pattern": "AhrefsBot",
     "addition_date": "2011/08/28",
     "instances": []
   },

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -1908,5 +1908,147 @@
       "Mozilla/5.0+(compatible;+PiplBot;+http://www.pipl.com/bot/)"
     ],
     "url": "http://www.pipl.com/bot/"
-  }  
+  },
+  {
+    "pattern": "Discordbot",
+    "addition_date": "2017/09/22",
+    "url": "https://discordapp.com"
+  },
+  {
+    "pattern": "TelegramBot",
+    "addition_date": "2017/10/01"
+  },
+  {
+    "pattern": "InfoPath.2",
+    "addition_date": "2017/10/07"
+  },
+  {
+    "pattern": "Jetslide",
+    "addition_date": "2017/09/27",
+    "url": "http://jetsli.de/crawler"
+  },
+  {
+    "pattern": "newsharecounts",
+    "addition_date": "2017/09/30",
+    "url": "http://newsharecounts.com/crawler"
+  },
+  {
+    "pattern": "James BOT",
+    "addition_date": "2017/10/12",
+    "url": "http://cognitiveseo.com/bot.html"
+  },
+  {
+    "pattern": "Barkrowler",
+    "addition_date": "2017/10/09",
+    "url": "http://www.exensa.com/crawl"
+  },
+  {
+    "pattern": "TinEye-bot",
+    "addition_date": "2017/10/14",
+    "url": "http://www.tineye.com/crawler.html"
+  },
+  {
+    "pattern": "CCBot",
+    "addition_date": "2017/10/18",
+    "url": "http://commoncrawl.org/faq/"
+  },
+  {
+    "pattern": "SocialRankIOBot",
+    "addition_date": "2017/10/19",
+    "url": "http://socialrank.io/about"
+  },
+  {
+    "pattern": "Yeti",
+    "addition_date": "2017/09/26",
+    "url": "http://naver.me/bot"
+  },
+  {
+    "pattern": "trendictionbot",
+    "addition_date": "2017/10/30",
+    "url": "http://www.trendiction.de/bot"
+  },
+  {
+    "pattern": "Ocarinabot",
+    "addition_date": "2017/09/27"
+  },
+  {
+    "pattern": "epicbot",
+    "addition_date": "2017/10/31",
+    "url": "http://www.epictions.com/epicbot"
+  },
+  {
+    "pattern": "SEMrushBot",
+    "addition_date": "2017/09/27"
+  },
+  {
+    "pattern": "Primalbot",
+    "addition_date": "2017/09/27",
+    "url": "https://www.primal.com"
+  },
+  {
+    "pattern": "DuckDuckGo-Favicons-Bot",
+    "addition_date": "2017/10/06",
+    "url": "http://duckduckgo.com"
+  },
+  {
+    "pattern": "GnowitNewsbot",
+    "addition_date": "2017/10/30",
+    "url": "http://www.gnowit.com"
+  },
+  {
+    "pattern": "Leikibot",
+    "addition_date": "2017/09/24",
+    "url": "http://www.leiki.com"
+  },
+  {
+    "pattern": "LinkArchiver",
+    "addition_date": "2017/09/24"
+  },
+  {
+    "pattern": "YaK",
+    "addition_date": "2017/09/25",
+    "url": "http://linkfluence.com"
+  },
+  {
+    "pattern": "PaperLiBot",
+    "addition_date": "2017/09/25",
+    "url": "http://support.paper.li/entries/20023257-what-is-paper-li"
+  },
+  {
+    "pattern": "Digg Deeper",
+    "addition_date": "2017/09/26",
+    "url": "http://digg.com/about"
+  },
+  {
+    "pattern": "dcrawl",
+    "addition_date": "2017/09/22"
+  },
+  {
+    "pattern": "Snacktory",
+    "addition_date": "2017/09/23",
+    "url": "https://github.com/karussell/snacktory"
+  },
+  {
+    "pattern": "AndersPinkBot",
+    "addition_date": "2017/09/24",
+    "url": "http://anderspink.com/bot.html"
+  },
+  {
+    "pattern": "Fyrebot",
+    "addition_date": "2017/09/22"
+  },
+  {
+    "pattern": "EveryoneSocialBot",
+    "addition_date": "2017/09/22",
+    "url": "http://everyonesocial.com"
+  },
+  {
+    "pattern": "Mediatoolkitbot",
+    "addition_date": "2017/10/06",
+    "url": "http://mediatoolkit.com"
+  },
+  {
+    "pattern": "Luminator-robots",
+    "addition_date": "2017/09/22"
+  }
 ]

--- a/test_validation.py
+++ b/test_validation.py
@@ -14,7 +14,6 @@ def update_json_file(data):
     with open('crawler-user-agents.json', 'w') as f:
         json.dump(data, f, indent=2)
 
-
 @pytest.fixture
 def restore_original_json():
     # Load original version of crawler-user-agents.json
@@ -40,6 +39,7 @@ def assert_validate_passed():
 def test_simple_pass(restore_original_json):
     # the json must be an array of objects containing "pattern"
     # there must be more than 10 instances to pass
+    print("FNORD")
     user_agent_list = [{'pattern': 'foo',
                         'instances': ['foo',
                                       'afoo',
@@ -150,5 +150,25 @@ def test_case_sensitivity(restore_original_json):
                                       'foo\\',
                                       'FoofooFoo',
                                       'foot']}]
+    update_json_file(user_agent_list)
+    assert_validate_failed()
+
+def test_duplicate_case_insensitive_detection(restore_original_json):
+    # contract: fail if we have patterns that differ only in capitailization
+    user_agent_list = [{'pattern': 'foo',
+                        'instances': ['foo',
+                                      'afoo',
+                                      'foob',
+                                      'cfood',
+                                      '/foo/',
+                                      '\\foo\\',
+                                      ':foo:',
+                                      'foo.',
+                                      '!foo',
+                                      '/foo',
+                                      'foo\\',
+                                      'FoofooFoo',
+                                      'foot']},
+                       {'pattern': 'fOo'}]
     update_json_file(user_agent_list)
     assert_validate_failed()

--- a/validate.py
+++ b/validate.py
@@ -40,12 +40,11 @@ def main():
                                                                     count))
 
     # check for duplicates with different capitalization
-    patterns = sorted(entry['pattern'].lower() for entry in json_data)
-    last = ""
-    for pattern in patterns:
-        if pattern == last:
-            raise ValueError('Pattern {!r} is duplicated with different capitalization'.format(pattern))
-        last = pattern
+    pattern_counts = Counter(entry['pattern'].lower() for entry in json_data)
+    for pattern, count in pattern_counts.most_common():
+        if count > 1:
+            raise ValueError('Pattern {!r} is duplicated {} times with different capitalization'
+                             .format(pattern, count))
 
     # check that we match the given instances
     num_instances = 0

--- a/validate.py
+++ b/validate.py
@@ -39,6 +39,14 @@ def main():
             raise ValueError('Pattern {!r} appears {} times'.format(pattern,
                                                                     count))
 
+    # check for duplicates with different capitalization
+    patterns = sorted(entry['pattern'].lower() for entry in json_data)
+    last = ""
+    for pattern in patterns:
+        if pattern == last:
+            raise ValueError('Pattern {!r} is duplicated with different capitalization'.format(pattern))
+        last = pattern
+
     # check that we match the given instances
     num_instances = 0
     for entry in json_data:


### PR DESCRIPTION
I noticed that I was running into problems with the latest crawler-user-agents and realised that there were some duplicates that weren't being caught by validate.py as the patterns had different case (rather than having a single pattern matching both capitalisations).

I've updated crawler-user-agents.json to ensure that we're still passing the validation with this slightly more stringent check.

I am *not* a python person, so definitely improve my validate.py addition if there is a better way of doing this