### PR TITLE
Added links to other repos in README (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 
-The Github repository `crawler-user-agents` contains a list of of HTTP user-agents used by robots/crawlers/spiders. I regularly maintain this list based on my own logs. I do welcome additions contributed as pull requests.
+This repository contains a list of of HTTP user-agents used by robots, crawlers, and spiders. I regularly maintain this list based on my own logs. 
+
+If you are using Ruby, [Voight-Kampff](https://github.com/biola/Voight-Kampff) and [isbot](https://github.com/Hentioe/isbot) provide  libraries for accessing this data.
+
+Other systems for spotting robots, crawlers, and spiders that you may want to consider include [isBot](https://github.com/gorangajic/isbot) (Node.JS), [Crawler-Detect](https://github.com/JayBizzle/Crawler-Detect) (PHP), [BrowserDetector](https://github.com/mimmi20/BrowserDetector) (PHP), and [browscap](https://github.com/browscap/browscap) (JSON files).
+
+## License
+
+The list is under a [MIT License](https://opensource.org/licenses/MIT). The versions prior to Nov 7, 2016 were under a [CC-SA](http://creativecommons.org/licenses/by-sa/3.0/) license.
+
+## Contributing
+
+I do welcome additions contributed as pull requests.
 
 The pull requests should:
 
@@ -16,7 +28,5 @@ Example:
       "url": "http://moz.com/help/pro/what-is-rogerbot-"
     }
 
-
-The list is under a [MIT License](https://opensource.org/licenses/MIT). The versions prior to Nov 7, 2016 were under a [CC-SA](http://creativecommons.org/licenses/by-sa/3.0/) license.
 
 --Martin


### PR DESCRIPTION
Pull request to fix #76 

This adds links to language specific front-ends to crawler-user-agents, and to other repositories that are alternatives to crawler-user-agents.

Thanks