### PR TITLE
Add BLP_bbot

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -2404,5 +2404,12 @@
       "Mozilla/5.0 (compatible; oBot/2.3.1; +http://filterdb.iss.net/crawler/)"
     ],
     "url": "http://filterdb.iss.net/crawler/"
+  },
+  {
+    "pattern": "BLP_bbot",
+    "addition_date": "2018/03/20",
+    "instances": [
+      "BLP_bbot/0.1"
+    ]
   }
 ]


### PR DESCRIPTION
This agent doesn’t identify itself very well. From what I can tell, it appears to be a Bloomberg News scraper/crawler, per this [source](https://lyte.id.au/2010/02/04/wtf-is-blp_bbot/).

We’re seeing a lot of instances of this on our 30+ magazine websites.