### PR TITLE
Add newspaper

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -2404,5 +2404,14 @@
       "Mozilla/5.0 (compatible; oBot/2.3.1; +http://filterdb.iss.net/crawler/)"
     ],
     "url": "http://filterdb.iss.net/crawler/"
+  },
+  {
+    "pattern": "newspaper\\/",
+    "addition_date": "2018/03/20",
+    "instances": [
+      "newspaper/0.2.5",
+      "newspaper/0.2.6",
+      "newspaper/0.1.0.7"
+    ]
   }
 ]


### PR DESCRIPTION
This bot doesn’t identify itself, other than `newspaper` and a version number. I did some Googling and found it in some other lists, but couldn’t directly identify who runs it. Our logs are showing this as scraping the HTML server-side, but not loading any client-side Javascript.