### PR TITLE
[fix] Unintentional match with LCC

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -2403,7 +2403,7 @@
     "url": "https://github.com/ArchiveTeam/ArchiveBot"
   },
   {
-    "pattern": "LCC",
+    "pattern": "^LCC$",
     "addition_date": "2018/02/28",
     "instances": [
       "LCC (+http://corpora.informatik.uni-leipzig.de/crawler_faq.html)"


### PR DESCRIPTION
LCC false positives non-crawler UAs like below.

```
Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; YTB730; BTRS99921; GTB7.5; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; Tablet PC 2.0; .NET4.0C; CIBA)
Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.0.30729; Tablet PC 2.0; .NET CLR 3.5.30729)
Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; YTB720; GTB7.5; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30618; .NET4.0C; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; BRI/2)
```