### PR TITLE
Add Datafeedwatch

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -3004,5 +3004,13 @@
      "instances": [
        "AdsTxtCrawler/1.0"
      ]
+  },
+  {
+    "pattern": "Datafeedwatch",
+    "addition_date": "2018/09/05",
+    "instances": [
+      "Datafeedwatch/2.1.x"
+    ],
+    "url": "https://www.datafeedwatch.com/"
   }
 ]


### PR DESCRIPTION
This PR adds `Datafeedwatch`, a bot used by a tool called DataFeedWatch that allows you to monitor product listings.