### PR TITLE
Add TangibleeBot

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -3004,5 +3004,13 @@
      "instances": [
        "AdsTxtCrawler/1.0"
      ]
+  },
+  {
+    "pattern": "TangibleeBot",
+    "addition_date": "2018/09/05",
+    "instances": [
+      "TangibleeBot/1.0.0.0 (http://tangiblee.com/bot)"
+    ],
+    "url": "http://tangiblee.com/bot"
   }
 ]


### PR DESCRIPTION
This PR adds `TangibleeBot`, a bot used by a service called Tangiblee, the bot scans web pages for data that it then uses to produce a product comparison tool.

You can find out more about the service here: http://tangiblee.com

