### PR TITLE
Add Zabbix

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -3004,5 +3004,13 @@
      "instances": [
        "AdsTxtCrawler/1.0"
      ]
+  },
+  {
+    "pattern": "Zabbix",
+    "addition_date": "2018/09/05",
+    "instances": [
+      "Zabbix"
+    ],
+    "url": "https://www.zabbix.com/documentation/3.4/manual/web_monitoring"
   }
 ]


### PR DESCRIPTION
This PR adds `Zabbix`, a bot used by a tool called [Zabbix](https://www.zabbix.com/), the bot checks for a HTTP response as part of monitoring the uptime of services.