### PR TITLE
Add Jersey

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -3460,4 +3460,12 @@
     ],
     "url": "https://webdatastats.com/"
   }
+  ,
+  {
+   "pattern": "HttpUrlConnection",
+    "addition_date": "2018/10/08",
+    "instances": [
+      "Jersey/2.25.1 (HttpUrlConnection 1.8.0_141)"
+    ]
+  }
 ]


### PR DESCRIPTION
I'm not sure, because Jersey is wrapper around HttpUrlConnection Java-library,
which is also in the User-Agent header, as I understood.