### PR TITLE
Add outbrain and w3c bots

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -3486,4 +3486,85 @@
     ],
     "url": "http://suite.seozoom.it/bot.html"
   }
+  ,
+  {
+    "pattern": "outbrain",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "Mozilla/5.0 (Java) outbrain"
+    ],
+    "url": "https://www.outbrain.com/help/advertisers/invalid-url/"
+  }
+  ,
+  {
+    "pattern": "W3C_Validator",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "W3C_Validator/1.3"
+    ],
+    "url": "https://validator.w3.org/services"
+  }
+  ,
+  {
+    "pattern": "Validator\\.nu",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "Validator.nu/LV"
+    ],
+    "url": "https://validator.w3.org/services"
+  }
+  ,
+  {
+    "pattern": "W3C-checklink",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "W3C-checklink"
+    ],
+    "url": "https://validator.w3.org/services"
+  }
+  ,
+  {
+    "pattern": "W3C-mobileOK",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "W3C-mobileOK/DDC-1.0"
+    ],
+    "url": "https://validator.w3.org/services"
+  }
+  ,
+  {
+    "pattern": "W3C_I18n-Checker",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "W3C_I18n-Checker/1.0"
+    ],
+    "url": "https://validator.w3.org/services"
+  }
+  ,
+  {
+    "pattern": "FeedValidator",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "FeedValidator/1.3"
+    ],
+    "url": "https://validator.w3.org/services"
+  }
+  ,
+  {
+    "pattern": "W3C_CSS_Validator",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "Jigsaw/2.3.0 W3C_CSS_Validator_JFouffa/2.0"
+    ],
+    "url": "https://validator.w3.org/services"
+  }
+  ,
+  {
+    "pattern": "W3C_Unicorn",
+    "addition_date": "2018/10/14",
+    "instances": [
+      "W3C_Unicorn/1.0"
+    ],
+    "url": "https://validator.w3.org/services"
+  }
 ]


### PR DESCRIPTION
Adds Outbrain and the W3C validator bots listed [here](https://validator.w3.org/services) other than NING which is [already present](https://github.com/monperrus/crawler-user-agents/blob/master/crawler-user-agents.json#L2518-L2521).