### PR TITLE
Add Google Favicon bot

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -3801,5 +3801,12 @@
       "Mozilla/5.0 (compatible; AddSearchBot/0.9; +http://www.addsearch.com/bot; info@addsearch.com)"
     ],
     "url": "http://www.addsearch.com/bot"
+  },
+  {
+    "pattern": "Google Favicon",
+    "addition_date": "2019/03/14",
+    "instances": [
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36 Google Favicon"
+    ]
   }
 ]


### PR DESCRIPTION
I could not find an official URL, but here are three links I found on the internet (there are more, but I picked three arbitrarily):

https://www.distilnetworks.com/bot-directory/bot/google-favicon/
https://www.seroundtable.com/google-favicon-crawler-26522.html
https://twitter.com/VorticonCmdr/status/1051851131499020288

I've been seeing this User-Agent in my webserver logs.