### PR TITLE
Added git page to package.json and changed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a list of of HTTP user-agents used by robots, crawlers,
 
 ## Install
 
-### Direct download 
+### Direct download
 
 Download the [`crawler-user-agents.json` file](https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json) from this repository directly.
 
@@ -12,9 +12,9 @@ Download the [`crawler-user-agents.json` file](https://raw.githubusercontent.com
 Install using npm or Yarn, or d
 
 ```sh
-npm install --save "https://github.com/monperrus/crawler-user-agents.git"
+npm install --save crawler-user-agents
 # OR
-yarn add "https://github.com/monperrus/crawler-user-agents.git"
+yarn add crawler-user-agents
 ```
 
 In Node.js, you can `require` the package to get an array of crawler user agents.

--- a/package.json
+++ b/package.json
@@ -3,5 +3,15 @@
   "version": "1.0.0",
   "main": "crawler-user-agents.json",
   "author": "Martin Monperrus <martin.monperrus@gnieh.org>",
-  "license": "MIT"
+  "license": "MIT",
+  "description": "This repository contains a list of of HTTP user-agents used by robots, crawlers, and spiders as in single JSON file.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monperrus/crawler-user-agents.git"
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/monperrus/crawler-user-agents/issues"
+  },
+  "homepage": "https://github.com/monperrus/crawler-user-agents#readme"
 }


### PR DESCRIPTION
Hi Martin, thanks for your work. It is extremely useful repo, but now there are several errors in npm setup.
1. All npm packages can be installed without git-repo url
2. [Npm page](https://www.npmjs.com/package/crawler-user-agents) hasn't link to github repo in the info column

This PR will correct errors after `npm publish`.
