### PR TITLE
Adding instance to duckduckgo

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -1183,7 +1183,8 @@
     "instances": [
       "DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)",
       "DuckDuckBot/1.1; (+http://duckduckgo.com/duckduckbot.html)",
-      "Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)"
+      "Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)",
+      "'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)'"
     ]
   }
   ,


### PR DESCRIPTION
This entry seemed weird to me as well, so I did a little bit of log-crawling.
I isolated the calls from DuckDuckGo and then grouped by UAs and IPs, and those are the results:

    Mozilla/5.0 (compatible; DuckDuckGo-Favicons-Bot/1.0; +http://duckduckgo.com)
      1 - 54.208.102.37
      201 - 107.21.1.8
    Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)
      4 - 52.204.97.54
      1 - 50.16.241.117
      1 - 50.16.247.234
      1 - 50.16.241.113
    'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)'
      126 - 52.204.97.54
      2 - 50.16.241.117
      1 - 50.16.247.234

The fact that all IPs that use the "weird" UA are in the list available at https://duckduckgo.com/duckduckbot, makes me think this UA is legittimate.