### PR TITLE
add Bytespider

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -4020,7 +4020,8 @@
   {
     "pattern": "Bytespider",
     "addition_date": "2019/11/11",
-    "instances": []
+    "instances": [],
+    "url": "https://stackoverflow.com/questions/57908900/what-is-the-bytespider-user-agent"
   }
 ]
 

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -4016,5 +4016,11 @@
     ],
     "url": "http://it.region-stuttgart.de/competenzatlas/unternehmen-suchen/"
   }
+  ,
+  {
+    "pattern": "Bytespider",
+    "addition_date": "2019/11/11",
+    "instances": []
+  }
 ]
 


### PR DESCRIPTION
We see a large amount of bot traffic with agents ending with 'Bytespider'. One example: "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.5939.1534 Mobile Safari/537.36; Bytespider".

I started to include an instances list, but then realized it presents with literally thousands of different user agent strings.

see:
https://stackoverflow.com/questions/57908900/what-is-the-bytespider-user-agent

https://udger.com/resources/ua-list/bot-detail?bot=ByteDance+crawler

I couldn't find any official web page for this crawler to include in the JSON for this crawler.