### PR TITLE
Added Google+ crawler

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -4079,4 +4079,10 @@
     ],
     "url": "https://support.google.com/webmasters/answer/9008080"
   }
+  ,
+  {
+  "pattern": "\+https:\/\/developers\.google\.com\/\+\/web\/snippet\/",
+  "addition_date": "2020/01/31",
+  "instances" : ["Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 Google (+https://developers.google.com/+/web/snippet/)"]
+}
 ]


### PR DESCRIPTION
Added:

Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 Google (+https://developers.google.com/web/snippet/)