### PR TITLE
Add async Python HTTP Clients

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -181,6 +181,17 @@
   }
   ,
   {
+    "pattern": "aiohttp",
+    "addition_date": "2019/12/23",
+    "instances": [
+      "Python/3.9 aiohttp/3.7.3",
+      "Python/3.8 aiohttp/3.7.2",
+      "Python/3.7 aiohttp/3.6.2a2"
+    ],
+    "url": "https://docs.aiohttp.org/en/stable/"
+  }
+  ,
+  {
     "pattern": "libwww-perl",
     "instances": [
       "2Bone_LinkChecker/1.0 libwww-perl/6.03",

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -192,6 +192,17 @@
   }
   ,
   {
+    "pattern": "httpx",
+    "addition_date":" 2019/12/23",
+    "instances": [
+      "python-httpx/0.16.1",
+      "python-httpx/0.13.0.dev1"
+      
+    ],
+    "url": "https://www.python-httpx.org"
+  }
+  ,
+  {
     "pattern": "libwww-perl",
     "instances": [
       "2Bone_LinkChecker/1.0 libwww-perl/6.03",


### PR DESCRIPTION
At the moment only sync Python HTTP clients is defined as bot, in this PR, I add detection of async clients [aiohttp](https://docs.aiohttp.org) and [httpx](https://github.com/encode/httpx).