### PR TITLE
Add Google-Certificates-Bridge.

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -4782,5 +4782,12 @@
       "PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.4.11 curl/7.69.1"
     ],
     "url": "https://github.com/php-curl-class/php-curl-class"
+  },
+  {
+    "pattern": "Google-Certificates-Bridge",
+    "addition_date": "2020/12/23",
+    "instances": [
+      "Google-Certificates-Bridge"
+    ]
   }
 ]


### PR DESCRIPTION
This showed up in some logs for a Google Cloud-hosted site while creating HTTPS certificates. It's used for domain verification under the [RFC 8555](https://tools.ietf.org/html/rfc8555) protocol.