### PR TITLE
Add webpagetest.org (PTST)

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -4866,5 +4866,14 @@
       "AppEngine-Google; (+http:\/\/code.google.com\/appengine; appid: s~virustotalcloud)"
     ],
     "url": "https://www.virustotal.com/gui/home/url"
+  },
+  {
+    "pattern": "(^| )PTST/",
+    "addition_date": "2021/12/05",
+    "instances": [
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36 PTST/211202.211915",
+      "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0 PTST/211202.211915"
+    ],
+    "url": "https://www.webpagetest.org"
   }
 ]

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -4868,7 +4868,7 @@
     "url": "https://www.virustotal.com/gui/home/url"
   },
   {
-    "pattern": "(^| )PTST/",
+    "pattern": "(^| )PTST\\/",
     "addition_date": "2021/12/05",
     "instances": [
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36 PTST/211202.211915",


### PR DESCRIPTION
https://www.webpagetest.org/. Adds PTST/<version> to the end of the user agent string by default.