### PR TITLE
Add Line chat crawler.

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -1359,6 +1359,15 @@
   }
   ,
   {
+    "pattern": "line-poker",
+    "addition_date": "2022/11/30",
+    "instances": [
+      "facebookexternalhit/1.1;line-poker/1.0"
+    ],
+    "url": "https://developers.line.biz/en/faq/tags/media/#how-are-the-url-previews-generated"
+  }
+  ,
+  {
     "pattern": "facebookexternalhit",
     "addition_date": "2012/05/07",
     "instances": [


### PR DESCRIPTION
Because Line also includes "facebookexternalhit" in the user agent, I put the pattern ahead of facebookexternalhit to prevent false positives with Facebook.