### PR TITLE
Use Node.js v20 in CI to have npm CLI version with support for --provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: pip3 install jsonschema pytest
       - run: py.test -vv
       - run: python3 validate.py  
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm install pacote@11.1.11
       - run: git checkout .


### PR DESCRIPTION
Addresses https://github.com/monperrus/crawler-user-agents/issues/342#issuecomment-2003594092