### PR TITLE
Add and use `requirements.txt`

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: pip3 install jsonschema pytest
+      - run: pip3 install -r requirements.txt
       - run: py.test -vv
       - run: python3 validate.py  
       - run: php validate.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python: 3.11.0
 
 install: 
-- pip3 install jsonschema pytest
+- pip3 install -r requirements.txt
 - npm clean-install
 
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+attrs==23.2.0
+iniconfig==2.0.0
+jsonschema==4.22.0
+jsonschema-specifications==2023.12.1
+packaging==24.0
+pluggy==1.5.0
+pytest==8.2.0
+referencing==0.35.0
+rpds-py==0.18.0


### PR DESCRIPTION
NOTE: I'm not very experienced with Python dependency management and pip. My goal here is similar to #351 but for pip.

This adds a `requirements.txt` file to pin Python dependencies, direct and transitive. This was achieved by, in a clean Docker image, first running `pip3 freeze` to get a list of irrelevant packages, then running the existing `pip3 install jsonschema pytest` (from CI) command, and finally running `pip3 freeze` again to get this project's dependencies (by omitting those from the first `pip3 freeze` list).

Both CIs have been updated to use the `requirements.txt` file to install dependencies. Besides improving reproducibility, this also avoids duplication.

The benefit of doing this is that the same versions of Python dependencies will always be used for this project (assuming pip respects the requirements). If the registry is trusted you can also be sure that the same source code is always run (however the absence of local checksums means this isn't the case if the registry isn't trusted).