### PR TITLE
Automatically tag new minor version release

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,0 +1,48 @@
+name: Update Minor Version and Tag
+
+on:
+  workflow_run:
+    workflows: [CI validation]
+    branches: [master]
+    types: 
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  update-minor-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # fetch all history for tags
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0 || echo "v1.0.0")
+          echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Increment minor version
+        id: increment_version
+        run: |
+          latest_tag="${{ steps.latest_tag.outputs.latest_tag }}"
+          # Remove 'v' prefix
+          version=${latest_tag#v}
+          # Split into parts
+          IFS='.' read -r major minor patch <<< "$version"
+          # Increment minor, reset patch
+          minor=$((minor + 1))
+          patch=0
+          new_tag="v${major}.${minor}.${patch}"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push new tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          new_tag="${{ steps.increment_version.outputs.new_tag }}"
+          git tag "$new_tag"
+          git push origin "$new_tag"


### PR DESCRIPTION
The Go package manager works using git tags. Without tagging new releases dependabot will for example not automatically update this dependency.

Tested first here: https://github.com/erikdubbelboer/github-action-tag-version-test

Fixes: https://github.com/monperrus/crawler-user-agents/issues/399