### PR TITLE
Give the npm Github Action write access

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,9 @@ on:
     types: 
       - completed
 
+permissions:
+  contents: write
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It needs this to be able to tag a new release.