### PR TITLE
Add Google-Ads-Conversions user agent

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -5165,5 +5165,13 @@
     "instances": [
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.168 Safari/537.36 DatadogSynthetics"
     ]
+  },
+  {
+    "pattern": "Google-Ads-Conversions",
+    "addition_date": "2025/09/10",
+    "url": "https://developers.google.com/google-ads/api/docs/conversions/upload-online",
+    "instances": [
+      "Mozilla/5.0 AppleWebKit/537.36 Chrome/139.0.7258.127 Safari/537.36 Google-Ads-Conversions"
+    ]
   }
 ]


### PR DESCRIPTION
## Description
Adds support for the Google-Ads-Conversions user agent to the crawler detection list.

## User Agent Added
- **Pattern**: `Google-Ads-Conversions`
- **Instance**: `Mozilla/5.0 AppleWebKit/537.36 Chrome/139.0.7258.127 Safari/537.36 Google-Ads-Conversions`
- **Official URL**: https://developers.google.com/google-ads/api/docs/conversions/upload-online

## Background
This user agent appears to be related to Google Ads Enhanced Conversions for Web feature. Based on Google's official documentation, this functionality involves sending user agent information when tracking conversion events for attribution purposes, though the specific user agent format is not explicitly documented.

The user agent has been observed in web traffic and follows the pattern of other Google advertising-related crawlers.

## References
- [Google Ads API Documentation - Enhanced Conversions for Web](https://developers.google.com/google-ads/api/docs/conversions/upload-online)
- [Tealium Documentation - Google Ads Enhanced Conversions](https://docs.tealium.com/server-side-connectors/google-ads-enhanced-conversions-for-web-connector/)

Partially addresses #360 (addresses the Google-Ads-Conversions user agent from the reported issue)