### PR TITLE
Add Observe Point UA

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -5173,5 +5173,11 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 Chrome/139.0.7258.127 Safari/537.36 Google-Ads-Conversions"
     ]
+  },
+  {
+    "pattern": "ObservePoint",
+    "addition_date": "2025/12/23",
+    "url": "https://help.observepoint.com/en/articles/9101465-allow-exclude-observepoint-traffic#h_2a8176c9b9",
+    "instances": []
   }
 ]


### PR DESCRIPTION
I preferred not to include the full list of user agents used by ObservePoint, as documented [here](https://help.observepoint.com/en/articles/9101465-allow-exclude-observepoint-traffic#h_2a8176c9b9), since it contains user agents equivalent to real browsers, and they change over time, making it difficult to keep in sync.

