### PR TITLE
replace createRequire with ESM import attributes

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,3 @@
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const crawlers = require('./crawler-user-agents.json');
+import crawlers from './crawler-user-agents.json' with { type: 'json' };
 
 export default crawlers;


### PR DESCRIPTION
Problem: `index.mjs` used import { createRequire } from 'node:module' to load the JSON file. The 'node:module' built-in is not available in edge runtimes, causing a error.

Solution: replace createRequire approach with the standard ESM Import Attributes syntax.