### PR TITLE
Add tags field to categorize crawler types

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Example:
       "pattern": "rogerbot",
       "addition_date": "2014/02/28",
       "url": "http://moz.com/help/pro/what-is-rogerbot-",
-      "instances" : ["rogerbot/2.3 example UA"]
+      "instances" : ["rogerbot/2.3 example UA"],
+      "tags": ["seo"]
     }
 
 ## License

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -12,7 +12,10 @@
       "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36"
     ],
-    "description": "Google's main web crawling bot for search indexing"
+    "description": "Google's main web crawling bot for search indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Googlebot-Mobile",
@@ -23,28 +26,40 @@
       "Nokia6820/2.0 (4.83) Profile/MIDP-1.0 Configuration/CLDC-1.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)",
       "SAMSUNG-SGH-E250/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)"
     ],
-    "description": "Google's legacy mobile crawler for Google Search indexing"
+    "description": "Google's legacy mobile crawler for Google Search indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Googlebot-Image",
     "instances": [
       "Googlebot-Image/1.0"
     ],
-    "description": "Google's image-specific web crawling bot for image search indexing"
+    "description": "Google's image-specific web crawling bot for image search indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Googlebot-News",
     "instances": [
       "Googlebot-News"
     ],
-    "description": "Google's news-specific web crawling bot for Google News indexing"
+    "description": "Google's news-specific web crawling bot for Google News indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Googlebot-Video",
     "instances": [
       "Googlebot-Video/1.0"
     ],
-    "description": "Google's video crawler for video-related Google Search features"
+    "description": "Google's video crawler for video-related Google Search features",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "AdsBot-Google([^-]|$)",
@@ -52,7 +67,10 @@
     "instances": [
       "AdsBot-Google (+http://www.google.com/adsbot.html)"
     ],
-    "description": "Google's Ads bot for checking web page ad quality"
+    "description": "Google's Ads bot for checking web page ad quality",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "AdsBot-Google-Mobile",
@@ -63,7 +81,10 @@
       "Mozilla/5.0 (Linux; Android 5.0; SM-G920A) AppleWebKit (KHTML, like Gecko) Chrome Mobile Safari (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)"
     ],
-    "description": "Google's mobile Ads bot for crawling mobile pages to serve targeted ads"
+    "description": "Google's mobile Ads bot for crawling mobile pages to serve targeted ads",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Feedfetcher-Google",
@@ -72,7 +93,10 @@
     "instances": [
       "Feedfetcher-Google; (+http://www.google.com/feedfetcher.html; 1 subscribers; feed-id=728742641706423)"
     ],
-    "description": "Google's feed fetcher bot for fetching RSS and Atom feeds for Google services"
+    "description": "Google's feed fetcher bot for fetching RSS and Atom feeds for Google services",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Mediapartners-Google",
@@ -83,14 +107,20 @@
       "Mozilla/5.0 (iPhone; U; CPU iPhone OS 10_0 like Mac OS X; en-us) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/10.0 Mobile/14A5297c Safari/602.1 (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)",
       "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7 (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)"
     ],
-    "description": "Google's Mediapartners bot for AdSense and AdMob crawling"
+    "description": "Google's Mediapartners bot for AdSense and AdMob crawling",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Mediapartners \\(Googlebot\\)",
     "addition_date": "2017/08/08",
     "url": "https://support.google.com/webmasters/answer/1061943?hl=en",
     "instances": [],
-    "description": "Google's Mediapartners bot variant for AdSense and AdMob crawling"
+    "description": "Google's Mediapartners bot variant for AdSense and AdMob crawling",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "APIs-Google",
@@ -99,7 +129,10 @@
     "instances": [
       "APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)"
     ],
-    "description": "Google's APIs bot for crawling API documentation and services"
+    "description": "Google's APIs bot for crawling API documentation and services",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Google-InspectionTool",
@@ -108,7 +141,10 @@
       "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Google-InspectionTool/1.0)",
       "Mozilla/5.0 (compatible; Google-InspectionTool/1.0)"
     ],
-    "description": "Google's inspection tool bot for testing and debugging search indexing"
+    "description": "Google's inspection tool bot for testing and debugging search indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Storebot-Google",
@@ -117,7 +153,10 @@
       "Mozilla/5.0 (X11; Linux x86_64; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
       "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36"
     ],
-    "description": "Google's Storebot for crawling product and e-commerce pages"
+    "description": "Google's Storebot for crawling product and e-commerce pages",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "GoogleOther",
@@ -125,7 +164,10 @@
     "instances": [
       "GoogleOther"
     ],
-    "description": "Google's other bots and services for various Google search features"
+    "description": "Google's other bots and services for various Google search features",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "bingbot",
@@ -146,7 +188,10 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Safari/537.36",
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/103.0.5060.134 Safari/537.36"
     ],
-    "description": "Microsoft's web crawling bot for Bing search indexing"
+    "description": "Microsoft's web crawling bot for Bing search indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Slurp",
@@ -156,7 +201,10 @@
       "Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)",
       "Mozilla/5.0 (compatible; Yahoo! Slurp China; http://misc.yahoo.com.cn/help.html)"
     ],
-    "description": "Yahoo's web crawling bot for Yahoo search indexing"
+    "description": "Yahoo's web crawling bot for Yahoo search indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "[wW]get",
@@ -165,7 +213,10 @@
       "Wget/1.14 (linux-gnu)",
       "Wget/1.20.3 (linux-gnu)"
     ],
-    "description": "GNU Wget command-line tool for downloading web content"
+    "description": "GNU Wget command-line tool for downloading web content",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "LinkedInBot",
@@ -174,7 +225,10 @@
       "LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/4.3 +http://www.linkedin.com)",
       "LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)"
     ],
-    "description": "LinkedIn's bot for crawling professional content and profiles"
+    "description": "LinkedIn's bot for crawling professional content and profiles",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Python-urllib",
@@ -191,7 +245,10 @@
       "Python-urllib/3.6",
       "Python-urllib/3.7"
     ],
-    "description": "Python's built-in URL library for HTTP requests"
+    "description": "Python's built-in URL library for HTTP requests",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "python-requests",
@@ -205,7 +262,10 @@
       "python-requests/2.21.0",
       "python-requests/2.22.0"
     ],
-    "description": "Popular Python HTTP library for making web requests"
+    "description": "Popular Python HTTP library for making web requests",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "aiohttp",
@@ -216,7 +276,10 @@
       "Python/3.7 aiohttp/3.6.2a2"
     ],
     "url": "https://docs.aiohttp.org/en/stable/",
-    "description": "Asynchronous HTTP client library for Python"
+    "description": "Asynchronous HTTP client library for Python",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "httpx",
@@ -226,7 +289,10 @@
       "python-httpx/0.13.0.dev1"
     ],
     "url": "https://www.python-httpx.org",
-    "description": "Modern Python HTTP client with async support"
+    "description": "Modern Python HTTP client with async support",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "libwww-perl",
@@ -235,14 +301,20 @@
       "2Bone_LinkChkr/1.0 libwww-perl/6.03",
       "amibot - http://www.amidalla.de - tech@amidalla.com libwww-perl/5.831"
     ],
-    "description": "Perl library for making HTTP requests and web crawling"
+    "description": "Perl library for making HTTP requests and web crawling",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "httpunit",
     "instances": [
       "httpunit/1.x"
     ],
-    "description": "Java library for automated web application testing"
+    "description": "Java library for automated web application testing",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Nutch",
@@ -251,7 +323,10 @@
       "NutchCVS/0.7.1 (Nutch; http://lucene.apache.org/nutch/bot.html; nutch-agent@lucene.apache.org)",
       "istellabot-nutch/Nutch-1.10"
     ],
-    "description": "Apache Nutch open-source web crawler framework"
+    "description": "Apache Nutch open-source web crawler framework",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Go-http-client",
@@ -261,7 +336,10 @@
       "Go-http-client/1.1",
       "Go-http-client/2.0"
     ],
-    "description": "Go programming language HTTP client library"
+    "description": "Go programming language HTTP client library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "phpcrawl",
@@ -270,7 +348,10 @@
     "instances": [
       "phpcrawl"
     ],
-    "description": "PHP web crawler library for scraping websites"
+    "description": "PHP web crawler library for scraping websites",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "msnbot",
@@ -291,12 +372,18 @@
       "msnbot/2.0b (+http://search.msn.com/msnbot.htm).",
       "msnbot/2.0b (+http://search.msn.com/msnbot.htm)._"
     ],
-    "description": "Microsoft's search engine bot for web indexing"
+    "description": "Microsoft's search engine bot for web indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "jyxobot",
     "instances": [],
-    "description": "Jyxo search engine bot for web crawling"
+    "description": "Jyxo search engine bot for web crawling",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "FAST-WebCrawler",
@@ -306,7 +393,10 @@
       "FAST-WebCrawler/3.7/FirstPage (atw-crawler at fast dot no;http://fast.no/support/crawler.asp)",
       "FAST-WebCrawler/3.8"
     ],
-    "description": "FAST search engine web crawler for indexing"
+    "description": "FAST search engine web crawler for indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "FAST Enterprise Crawler",
@@ -314,14 +404,20 @@
       "FAST Enterprise Crawler 6 / Scirus scirus-crawler@fast.no; http://www.scirus.com/srsapp/contactus/",
       "FAST Enterprise Crawler 6 used by Schibsted (webcrawl@schibstedsok.no)"
     ],
-    "description": "FAST enterprise-grade web crawler for search"
+    "description": "FAST enterprise-grade web crawler for search",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "BIGLOTRON",
     "instances": [
       "BIGLOTRON (Beta 2;GNU/Linux)"
     ],
-    "description": "Biglotron search engine web crawler bot"
+    "description": "Biglotron search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Teoma",
@@ -330,7 +426,10 @@
       "Mozilla/2.0 (compatible; Ask Jeeves/Teoma; +http://about.ask.com/en/docs/about/webmasters.shtml)"
     ],
     "url": "http://about.ask.com/en/docs/about/webmasters.shtml",
-    "description": "Ask Jeeves Teoma search engine web crawler"
+    "description": "Ask Jeeves Teoma search engine web crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "convera",
@@ -338,7 +437,10 @@
       "ConveraCrawler/0.9e (+http://ews.converasearch.com/crawl.htm)"
     ],
     "url": "http://ews.converasearch.com/crawl.htm",
-    "description": "Convera search engine web crawler bot"
+    "description": "Convera search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "seekbot",
@@ -346,7 +448,10 @@
       "Seekbot/1.0 (http://www.seekbot.net/bot.html) RobotsTxtFetcher/1.2"
     ],
     "url": "http://www.seekbot.net/bot.html",
-    "description": "Seekbot search engine web crawler for indexing"
+    "description": "Seekbot search engine web crawler for indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Gigabot",
@@ -355,7 +460,10 @@
       "Gigabot/2.0 (http://www.gigablast.com/spider.html)"
     ],
     "url": "http://www.gigablast.com/spider.html",
-    "description": "Gigablast search engine web crawler bot"
+    "description": "Gigablast search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Gigablast",
@@ -363,7 +471,10 @@
       "GigablastOpenSource/1.0"
     ],
     "url": "https://github.com/gigablast/open-source-search-engine",
-    "description": "Gigablast open-source search engine crawler"
+    "description": "Gigablast open-source search engine crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "exabot",
@@ -375,7 +486,10 @@
       "Mozilla/5.0 (compatible; Exabot/3.0; +http://www.exabot.com/go/robot)",
       "Mozilla/5.0 (compatible; Exabot/3.0;  http://www.exabot.com/go/robot)"
     ],
-    "description": "Exabot search engine web crawler for indexing"
+    "description": "Exabot search engine web crawler for indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "ia_archiver",
@@ -383,26 +497,38 @@
       "ia_archiver (+http://www.alexa.com/site/help/webmasters; crawler@alexa.com)",
       "ia_archiver-web.archive.org"
     ],
-    "description": "Internet Archive Wayback Machine web crawler"
+    "description": "Internet Archive Wayback Machine web crawler",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "GingerCrawler",
     "instances": [
       "GingerCrawler/1.0 (Language Assistant for Dyslexics; www.gingersoftware.com/crawler_agent.htm; support at ginger software dot com)"
     ],
-    "description": "Ginger Software's language assistant web crawler"
+    "description": "Ginger Software's language assistant web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "webmon ",
     "instances": [],
-    "description": "Webmon website monitoring and crawling bot"
+    "description": "Webmon website monitoring and crawling bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "HTTrack",
     "instances": [
       "Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)"
     ],
-    "description": "HTTrack website copier for offline browsing"
+    "description": "HTTrack website copier for offline browsing",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "grub\\.org",
@@ -419,22 +545,34 @@
       "Mozilla/4.0 (compatible; grub-client-1.4.3; Crawl your own stuff with http://grub.org)",
       "Mozilla/4.0 (compatible; grub-client-1.5.3; Crawl your own stuff with http://grub.org)"
     ],
-    "description": "Grub search engine web crawler for indexing"
+    "description": "Grub search engine web crawler for indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "UsineNouvelleCrawler",
     "instances": [],
-    "description": "Usine Nouvelle news site web crawler"
+    "description": "Usine Nouvelle news site web crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "antibot",
     "instances": [],
-    "description": "Antibot web crawler for content discovery"
+    "description": "Antibot web crawler for content discovery",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "netresearchserver",
     "instances": [],
-    "description": "Net Research Server web crawler bot"
+    "description": "Net Research Server web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "speedy",
@@ -445,12 +583,18 @@
       "Speedy Spider (Entireweb; Beta/1.2; http://www.entireweb.com/about/search_tech/speedyspider/)",
       "Speedy Spider (http://www.entireweb.com/about/search_tech/speedy_spider/)"
     ],
-    "description": "Entireweb Speedy Spider web crawler bot"
+    "description": "Entireweb Speedy Spider web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "fluffy",
     "instances": [],
-    "description": "Fluffy search engine web crawler bot"
+    "description": "Fluffy search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "findlink",
@@ -479,19 +623,28 @@
       "findlinks/2.5 (+http://wortschatz.uni-leipzig.de/findlinks/)",
       "findlinks/2.6 (+http://wortschatz.uni-leipzig.de/findlinks/)"
     ],
-    "description": "Findlinks web crawler for link discovery"
+    "description": "Findlinks web crawler for link discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "msrbot",
     "instances": [],
-    "description": "Microsoft Research web crawler bot"
+    "description": "Microsoft Research web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "panscient",
     "instances": [
       "panscient.com"
     ],
-    "description": "Panscient web crawler for content analysis"
+    "description": "Panscient web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "yacybot",
@@ -544,12 +697,19 @@
       "yacybot (-global; amd64 Linux 5.2.9-Jinsol; java 12.0.2; Europe/en) http://yacy.net/bot.html",
       "yacybot (-global; amd64 Linux 5.2.11-Jinsol; java 12.0.2; Europe/en) http://yacy.net/bot.html"
     ],
-    "description": "YaCy decentralized search engine web crawler"
+    "description": "YaCy decentralized search engine web crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "AISearchBot",
     "instances": [],
-    "description": "AI-powered search engine web crawler bot"
+    "description": "AI-powered search engine web crawler bot",
+    "tags": [
+      "search-engine",
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "ips-agent",
@@ -560,12 +720,18 @@
       "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.24; ips-agent) Gecko/20111107 Ubuntu/10.04 (lucid) Firefox/3.6.24",
       "Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:14.0; ips-agent) Gecko/20100101 Firefox/14.0.1"
     ],
-    "description": "IPS agent web crawler for content indexing"
+    "description": "IPS agent web crawler for content indexing",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "tagoobot",
     "instances": [],
-    "description": "Tagoo search engine web crawler bot"
+    "description": "Tagoo search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "MJ12bot",
@@ -591,7 +757,10 @@
       "Mozilla/5.0 (compatible; MJ12bot/v1.4.7; http://www.majestic12.co.uk/bot.php?+)",
       "Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)"
     ],
-    "description": "Majestic-12 search engine web crawler bot"
+    "description": "Majestic-12 search engine web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "woriobot",
@@ -599,28 +768,40 @@
       "Mozilla/5.0 (compatible; woriobot +http://worio.com)",
       "Mozilla/5.0 (compatible; woriobot support [at] zite [dot] com +http://zite.com)"
     ],
-    "description": "Worio search engine web crawler bot"
+    "description": "Worio search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "yanga",
     "instances": [
       "Yanga WorldSearch Bot v1.1/beta (http://www.yanga.co.uk/)"
     ],
-    "description": "Yanga search engine web crawler bot"
+    "description": "Yanga search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "buzzbot",
     "instances": [
       "Buzzbot/1.0 (Buzzbot; http://www.buzzstream.com; buzzbot@buzzstream.com)"
     ],
-    "description": "Buzzstream web crawler for link research"
+    "description": "Buzzstream web crawler for link research",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "mlbot",
     "instances": [
       "MLBot (www.metadatalabs.com/mlbot)"
     ],
-    "description": "Metadata Labs web crawler for analysis"
+    "description": "Metadata Labs web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "yandex\\.com\\/bots",
@@ -669,13 +850,19 @@
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36 (compatible; YandexScreenshotBot/3.0; +http://yandex.com/bots)"
     ],
     "addition_date": "2015/04/14",
-    "description": "Yandex search engine web crawler bots"
+    "description": "Yandex search engine web crawler bots",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "purebot",
     "addition_date": "2010/01/19",
     "instances": [],
-    "description": "Pure web crawler for content discovery"
+    "description": "Pure web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Linguee Bot",
@@ -685,7 +872,10 @@
       "Linguee Bot (http://www.linguee.com/bot)",
       "Linguee Bot (http://www.linguee.com/bot; bot@linguee.com)"
     ],
-    "description": "Linguee translation web crawler bot"
+    "description": "Linguee translation web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "CyberPatrol",
@@ -694,7 +884,10 @@
     "instances": [
       "CyberPatrol SiteCat Webbot (http://www.cyberpatrol.com/cyberpatrolcrawler.asp)"
     ],
-    "description": "CyberPatrol web content filtering bot"
+    "description": "CyberPatrol web content filtering bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "voilabot",
@@ -703,7 +896,10 @@
       "Mozilla/5.0 (Windows NT 5.1; U; Win64; fr; rv:1.8.1) VoilaBot BETA 1.2 (support.voilabot@orange-ftgroup.com)",
       "Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.8.1) VoilaBot BETA 1.2 (support.voilabot@orange-ftgroup.com)"
     ],
-    "description": "Voila search engine web crawler bot"
+    "description": "Voila search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Baiduspider",
@@ -713,13 +909,19 @@
       "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)",
       "Mozilla/5.0 (compatible; Baiduspider-render/2.0; +http://www.baidu.com/search/spider.html)"
     ],
-    "description": "Baidu search engine web crawler bot"
+    "description": "Baidu search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "citeseerxbot",
     "addition_date": "2010/07/17",
     "instances": [],
-    "description": "CiteSeerX academic web crawler bot"
+    "description": "CiteSeerX academic web crawler bot",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "spbot",
@@ -761,14 +963,20 @@
       "Mozilla/5.0 (compatible; spbot/5.0.3; +http://OpenLinkProfiler.org/bot )",
       "Mozilla/5.0 (compatible; spbot/5.0; +http://OpenLinkProfiler.org/bot )"
     ],
-    "description": "SEO Profiler web crawler for analysis"
+    "description": "SEO Profiler web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "twengabot",
     "addition_date": "2010/08/03",
     "url": "http://www.twenga.com/bot.html",
     "instances": [],
-    "description": "Twenga shopping web crawler bot"
+    "description": "Twenga shopping web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "postrank",
@@ -778,7 +986,10 @@
       "PostRank/2.0 (postrank.com)",
       "PostRank/2.0 (postrank.com; 1 subscribers)"
     ],
-    "description": "PostRank web crawler for content ranking"
+    "description": "PostRank web crawler for content ranking",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Turnitin",
@@ -788,14 +999,20 @@
       "TurnitinBot (https://turnitin.com/robot/crawlerinfo.html)",
       "Turnitin (https://bit.ly/2UvnfoQ)"
     ],
-    "description": "Turnitin plagiarism detection web crawler"
+    "description": "Turnitin plagiarism detection web crawler",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "scribdbot",
     "addition_date": "2010/09/28",
     "url": "http://www.scribd.com",
     "instances": [],
-    "description": "Scribd document web crawler bot"
+    "description": "Scribd document web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "page2rss",
@@ -804,7 +1021,10 @@
     "instances": [
       "Mozilla/5.0 (compatible;  Page2RSS/0.7; +http://page2rss.com/)"
     ],
-    "description": "Page2RSS web crawler for RSS conversion"
+    "description": "Page2RSS web crawler for RSS conversion",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "sitebot",
@@ -813,7 +1033,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Whoiswebsitebot/0.1; +http://www.whoiswebsite.net)"
     ],
-    "description": "Sitebot web crawler for site analysis"
+    "description": "Sitebot web crawler for site analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "linkdex",
@@ -828,13 +1051,20 @@
       "linkdex.com/v2.0",
       "linkdexbot/Nutch-1.0-dev (http://www.linkdex.com/; crawl at linkdex dot com)"
     ],
-    "description": "Linkdex SEO tool web crawler for link analysis"
+    "description": "Linkdex SEO tool web crawler for link analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Adidxbot",
     "url": "https://www.bing.com/webmasters/help/which-crawlers-does-bing-use-8c184ec0",
     "instances": [],
-    "description": "Bing's advertising index web crawler bot"
+    "description": "Bing's advertising index web crawler bot",
+    "tags": [
+      "advertising",
+      "search-engine"
+    ]
   },
   {
     "pattern": "ezooms",
@@ -843,7 +1073,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Ezooms/1.0; ezooms.bot@gmail.com)"
     ],
-    "description": "Ezooms search engine web crawler bot"
+    "description": "Ezooms search engine web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "dotbot",
@@ -852,7 +1085,10 @@
       "Mozilla/5.0 (compatible; DotBot/1.1; http://www.opensiteexplorer.org/dotbot, help@moz.com)",
       "dotbot"
     ],
-    "description": "Moz DotBot web crawler for SEO analysis"
+    "description": "Moz DotBot web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Mail\\.RU_Bot",
@@ -863,7 +1099,10 @@
       "Mozilla/5.0 (compatible; Mail.RU_Bot/2.0; +http://go.mail.ru/",
       "Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/Robots/2.0; +http://go.mail.ru/help/robots)"
     ],
-    "description": "Mail.RU search engine web crawler bot"
+    "description": "Mail.RU search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "discobot",
@@ -874,7 +1113,10 @@
       "Mozilla/5.0 (compatible; discobot/2.0; +http://discoveryengine.com/discobot.html)",
       "mozilla/5.0 (compatible; discobot/1.1; +http://discoveryengine.com/discobot.html)"
     ],
-    "description": "Discovery Engine web crawler for content discovery"
+    "description": "Discovery Engine web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "heritrix",
@@ -904,14 +1146,20 @@
       "Mozilla/5.0 (compatible; heritrix/3.3.0-SNAPSHOT-20160309-0050; UniLeipzigASV +http://corpora.informatik.uni-leipzig.de/crawler_faq.html)",
       "Mozilla/5.0 (compatible; sukibot_heritrix/3.1.1 +http://suki.ling.helsinki.fi/eng/webmasters.html)"
     ],
-    "description": "Internet Archive's Heritrix web crawler framework"
+    "description": "Internet Archive's Heritrix web crawler framework",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "findthatfile",
     "addition_date": "2011/06/21",
     "url": "http://www.findthatfile.com/",
     "instances": [],
-    "description": "FindThatFile web crawler for file discovery"
+    "description": "FindThatFile web crawler for file discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "europarchive\\.org",
@@ -920,7 +1168,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; MSIE 7.0 +http://www.europarchive.org)"
     ],
-    "description": "European Archive web crawler for preservation"
+    "description": "European Archive web crawler for preservation",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "NerdByNature\\.Bot",
@@ -929,7 +1180,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; NerdByNature.Bot; http://www.nerdbynature.net/bot)"
     ],
-    "description": "NerdByNature web crawler for content indexing"
+    "description": "NerdByNature web crawler for content indexing",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "(sistrix|SISTRIX) [cC]rawler",
@@ -938,7 +1192,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; SISTRIX Crawler; http://crawler.sistrix.net/)"
     ],
-    "description": "SISTRIX SEO tool web crawler for analysis"
+    "description": "SISTRIX SEO tool web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Ahrefs(Bot|SiteAudit)",
@@ -952,7 +1209,10 @@
       "Mozilla/5.0 (compatible; AhrefsBot/6.1; News; +http://ahrefs.com/robot/)",
       "Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)"
     ],
-    "description": "Ahrefs SEO tool web crawler for link analysis"
+    "description": "Ahrefs SEO tool web crawler for link analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "fuelbot",
@@ -960,7 +1220,10 @@
     "instances": [
       "fuelbot"
     ],
-    "description": "Fuel web crawler for content discovery"
+    "description": "Fuel web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "CrunchBot",
@@ -968,7 +1231,10 @@
     "instances": [
       "CrunchBot/1.0 (+http://www.leadcrunch.com/crunchbot)"
     ],
-    "description": "LeadCrunch web crawler for lead generation"
+    "description": "LeadCrunch web crawler for lead generation",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "IndeedBot",
@@ -976,7 +1242,10 @@
     "instances": [
       "Mozilla/5.0 (Windows NT 6.1; rv:38.0) Gecko/20100101 Firefox/38.0 (IndeedBot 1.1)"
     ],
-    "description": "Indeed job search web crawler bot"
+    "description": "Indeed job search web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "mappydata",
@@ -984,7 +1253,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Mappy/1.0; +http://mappydata.net/bot/)"
     ],
-    "description": "Mappy web crawler for mapping data"
+    "description": "Mappy web crawler for mapping data",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "woobot",
@@ -992,7 +1264,10 @@
     "instances": [
       "woobot"
     ],
-    "description": "Woo web crawler for content analysis"
+    "description": "Woo web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "ZoominfoBot",
@@ -1000,7 +1275,10 @@
     "instances": [
       "ZoominfoBot (zoominfobot at zoominfo dot com)"
     ],
-    "description": "ZoomInfo web crawler for business intelligence"
+    "description": "ZoomInfo web crawler for business intelligence",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "PrivacyAwareBot",
@@ -1008,7 +1286,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; PrivacyAwareBot/1.1; +http://www.privacyaware.org)"
     ],
-    "description": "PrivacyAware web crawler for privacy analysis"
+    "description": "PrivacyAware web crawler for privacy analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Multiviewbot",
@@ -1016,7 +1297,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Multiviewbot"
     ],
-    "description": "Multiview web crawler for content discovery"
+    "description": "Multiview web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SWIMGBot",
@@ -1024,7 +1308,10 @@
     "instances": [
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 Safari/537.36 SWIMGBot"
     ],
-    "description": "SWIMG web crawler for image discovery"
+    "description": "SWIMG web crawler for image discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Grobbot",
@@ -1032,7 +1319,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Grobbot/2.2; +https://grob.it)"
     ],
-    "description": "Grob web crawler for content analysis"
+    "description": "Grob web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "eright",
@@ -1040,7 +1330,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; eright/1.0; +bot@eright.com)"
     ],
-    "description": "Eright web crawler for content discovery"
+    "description": "Eright web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Apercite",
@@ -1048,7 +1341,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Apercite; +http://www.apercite.fr/robot/index.html)"
     ],
-    "description": "Apercite web crawler for content analysis"
+    "description": "Apercite web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "semanticbot",
@@ -1057,7 +1353,10 @@
       "semanticbot",
       "semanticbot (info@semanticaudience.com)"
     ],
-    "description": "Semantic web crawler for content analysis"
+    "description": "Semantic web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Aboundex",
@@ -1067,7 +1366,10 @@
       "Aboundex/0.2 (http://www.aboundex.com/crawler/)",
       "Aboundex/0.3 (http://www.aboundex.com/crawler/)"
     ],
-    "description": "Aboundex web crawler for content discovery"
+    "description": "Aboundex web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "domaincrawler",
@@ -1075,14 +1377,20 @@
     "instances": [
       "CipaCrawler/3.0 (info@domaincrawler.com; http://www.domaincrawler.com/www.example.com)"
     ],
-    "description": "Domain Crawler web crawler for analysis"
+    "description": "Domain Crawler web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "wbsearchbot",
     "addition_date": "2011/12/21",
     "url": "http://www.warebay.com/bot.html",
     "instances": [],
-    "description": "Warebay search web crawler bot"
+    "description": "Warebay search web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "summify",
@@ -1091,7 +1399,10 @@
     "instances": [
       "Summify (Summify/1.0.1; +http://summify.com)"
     ],
-    "description": "Summify web crawler for content summarization"
+    "description": "Summify web crawler for content summarization",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "CCBot",
@@ -1101,13 +1412,19 @@
       "CCBot/2.0 (http://commoncrawl.org/faq/)",
       "CCBot/2.0 (https://commoncrawl.org/faq/)"
     ],
-    "description": "Common Crawl web crawler for indexing"
+    "description": "Common Crawl web crawler for indexing",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "edisterbot",
     "addition_date": "2012/02/25",
     "instances": [],
-    "description": "Edister web crawler for content discovery"
+    "description": "Edister web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "SeznamBot",
@@ -1120,7 +1437,10 @@
       "Mozilla/5.0 (compatible; SeznamBot/3.2; +http://napoveda.seznam.cz/en/seznambot-intro/)",
       "Mozilla/5.0 (compatible; SeznamBot/4.0; +http://napoveda.seznam.cz/seznambot-intro/)"
     ],
-    "description": "Seznam search engine web crawler bot"
+    "description": "Seznam search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "ec2linkfinder",
@@ -1128,13 +1448,19 @@
     "instances": [
       "ec2linkfinder"
     ],
-    "description": "EC2 link finder web crawler bot"
+    "description": "EC2 link finder web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "gslfbot",
     "addition_date": "2012/04/03",
     "instances": [],
-    "description": "GSLFBOT web crawler for content discovery"
+    "description": "GSLFBOT web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "aiHitBot",
@@ -1142,13 +1468,19 @@
     "instances": [
       "Mozilla/5.0 (compatible; aiHitBot/2.9; +https://www.aihitdata.com/about)"
     ],
-    "description": "AiHit web crawler for data collection"
+    "description": "AiHit web crawler for data collection",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "intelium_bot",
     "addition_date": "2012/05/07",
     "instances": [],
-    "description": "Intelium web crawler for content discovery"
+    "description": "Intelium web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "facebookexternalhit",
@@ -1159,7 +1491,10 @@
       "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
     ],
     "url": "https://developers.facebook.com/docs/sharing/webmasters/crawler/",
-    "description": "Facebook external hit web crawler bot"
+    "description": "Facebook external hit web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Yeti",
@@ -1168,7 +1503,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Yeti/1.1; +http://naver.me/bot)"
     ],
-    "description": "Naver Yeti search engine web crawler bot"
+    "description": "Naver Yeti search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "RetrevoPageAnalyzer",
@@ -1176,13 +1514,19 @@
     "instances": [
       "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; RetrevoPageAnalyzer; +http://www.retrevo.com/content/about-us)"
     ],
-    "description": "Retrevo page analyzer web crawler bot"
+    "description": "Retrevo page analyzer web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "lb-spider",
     "addition_date": "2012/05/07",
     "instances": [],
-    "description": "LB spider web crawler for content discovery"
+    "description": "LB spider web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Sogou",
@@ -1193,21 +1537,30 @@
       "Sogou Pic Spider/3.0(+http://www.sogou.com/docs/help/webmasters.htm#07)",
       "Sogou web spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)"
     ],
-    "description": "Sogou search engine web crawler bot"
+    "description": "Sogou search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "lssbot",
     "addition_date": "2012/05/15",
     "url": "https://www.lssbot.com/",
     "instances": [],
-    "description": "LSS web crawler for content discovery"
+    "description": "LSS web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "careerbot",
     "addition_date": "2012/05/23",
     "url": "http://www.career-x.de/bot.html",
     "instances": [],
-    "description": "Career-X web crawler for job discovery"
+    "description": "Career-X web crawler for job discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "wotbox",
@@ -1217,14 +1570,20 @@
       "Wotbox/2.0 (bot@wotbox.com; http://www.wotbox.com)",
       "Wotbox/2.01 (+http://www.wotbox.com/bot/)"
     ],
-    "description": "Wotbox web crawler for content discovery"
+    "description": "Wotbox web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "wocbot",
     "addition_date": "2012/07/25",
     "url": "http://www.wocodi.com/crawler",
     "instances": [],
-    "description": "Wocodi web crawler for content discovery"
+    "description": "Wocodi web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "ichiro",
@@ -1247,7 +1606,10 @@
       "ichiro/4.0 (http://help.goo.ne.jp/door/crawler.html)",
       "ichiro/5.0 (http://help.goo.ne.jp/door/crawler.html)"
     ],
-    "description": "Goo ichiro search engine web crawler bot"
+    "description": "Goo ichiro search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "DuckDuckBot",
@@ -1259,13 +1621,19 @@
       "Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)",
       "'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)'"
     ],
-    "description": "DuckDuckGo search engine web crawler bot"
+    "description": "DuckDuckGo search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "lssrocketcrawler",
     "addition_date": "2012/09/24",
     "instances": [],
-    "description": "LSS Rocket web crawler for content"
+    "description": "LSS Rocket web crawler for content",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "drupact",
@@ -1274,45 +1642,66 @@
     "instances": [
       "drupact/0.7; http://www.arocom.de/drupact"
     ],
-    "description": "Drupact web crawler for content discovery"
+    "description": "Drupact web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "webcompanycrawler",
     "addition_date": "2012/10/03",
     "instances": [],
-    "description": "Web Company web crawler for analysis"
+    "description": "Web Company web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "acoonbot",
     "addition_date": "2012/10/07",
     "url": "http://www.acoon.de/robot.asp",
     "instances": [],
-    "description": "Acoon web crawler for content discovery"
+    "description": "Acoon web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "openindexspider",
     "addition_date": "2012/10/26",
     "url": "http://www.openindex.io/en/webmasters/spider.html",
     "instances": [],
-    "description": "OpenIndex web crawler for indexing"
+    "description": "OpenIndex web crawler for indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "gnam gnam spider",
     "addition_date": "2012/10/31",
     "instances": [],
-    "description": "Gnam Gnam web crawler for discovery"
+    "description": "Gnam Gnam web crawler for discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "web-archive-net\\.com\\.bot",
     "instances": [],
-    "description": "Web Archive web crawler for preservation"
+    "description": "Web Archive web crawler for preservation",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "backlinkcrawler",
     "addition_date": "2013/01/04",
     "url": "http://www.backlinktest.com/crawler.html",
     "instances": [],
-    "description": "Backlink Crawler web crawler for analysis"
+    "description": "Backlink Crawler web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "coccoc",
@@ -1331,7 +1720,10 @@
       "coccoc/1.0 (http://help.coccoc.com/)",
       "coccoc/1.0 (http://help.coccoc.vn/)"
     ],
-    "description": "Coccoc search engine web crawler bot"
+    "description": "Coccoc search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "integromedb",
@@ -1340,19 +1732,28 @@
     "instances": [
       "www.integromedb.org/Crawler"
     ],
-    "description": "IntegromeDB web crawler for research"
+    "description": "IntegromeDB web crawler for research",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "content crawler spider",
     "addition_date": "2013/01/11",
     "instances": [],
-    "description": "Content Crawler web crawler for discovery"
+    "description": "Content Crawler web crawler for discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "toplistbot",
     "addition_date": "2013/02/05",
     "instances": [],
-    "description": "TopList web crawler for ranking"
+    "description": "TopList web crawler for ranking",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "it2media-domain-crawler",
@@ -1361,13 +1762,19 @@
       "it2media-domain-crawler/1.0 on crawler-prod.it2media.de",
       "it2media-domain-crawler/2.0"
     ],
-    "description": "IT2Media domain web crawler bot"
+    "description": "IT2Media domain web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "ip-web-crawler\\.com",
     "addition_date": "2013/03/22",
     "instances": [],
-    "description": "IP Web Crawler web crawler bot"
+    "description": "IP Web Crawler web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "siteexplorer\\.info",
@@ -1376,13 +1783,19 @@
       "Mozilla/5.0 (compatible; SiteExplorer/1.0b; +http://siteexplorer.info/)",
       "Mozilla/5.0 (compatible; SiteExplorer/1.1b; +http://siteexplorer.info/Backlink-Checker-Spider/)"
     ],
-    "description": "Site Explorer web crawler for analysis"
+    "description": "Site Explorer web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "elisabot",
     "addition_date": "2013/06/27",
     "instances": [],
-    "description": "Elisa web crawler for content discovery"
+    "description": "Elisa web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "proximic",
@@ -1392,7 +1805,10 @@
       "Mozilla/5.0 (compatible; proximic; +http://www.proximic.com)",
       "Mozilla/5.0 (compatible; proximic; +http://www.proximic.com/info/spider.php)"
     ],
-    "description": "Proximic web crawler for content analysis"
+    "description": "Proximic web crawler for content analysis",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "changedetection",
@@ -1401,13 +1817,19 @@
     "instances": [
       "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1;  http://www.changedetection.com/bot.html )"
     ],
-    "description": "ChangeDetection web crawler for monitoring"
+    "description": "ChangeDetection web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "arabot",
     "addition_date": "2013/10/09",
     "instances": [],
-    "description": "Arabot web crawler for content discovery"
+    "description": "Arabot web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "WeSEE:Search",
@@ -1416,20 +1838,29 @@
       "WeSEE:Search",
       "WeSEE:Search/0.1 (Alpha, http://www.wesee.com/en/support/bot/)"
     ],
-    "description": "WeSEE search engine web crawler bot"
+    "description": "WeSEE search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "niki-bot",
     "addition_date": "2014/01/01",
     "instances": [],
-    "description": "Niki web crawler for content discovery"
+    "description": "Niki web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "CrystalSemanticsBot",
     "addition_date": "2014/02/17",
     "url": "http://www.crystalsemantics.com/user-agent/",
     "instances": [],
-    "description": "Crystal Semantics web crawler bot"
+    "description": "Crystal Semantics web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "rogerbot",
@@ -1450,7 +1881,10 @@
       "rogerbot/1.1 (http://moz.com/help/guides/search-overview/crawl-diagnostics#more-help, rogerbot-crawler+pr4-crawler-15@moz.com)",
       "rogerbot/1.2 (http://moz.com/help/pro/what-is-rogerbot-, rogerbot-crawler+phaser-testing-crawler-01@moz.com)"
     ],
-    "description": "Moz RogerBot web crawler for analysis"
+    "description": "Moz RogerBot web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "360Spider",
@@ -1468,7 +1902,10 @@
       "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0); 360Spider(compatible; HaosouSpider; http://www.haosou.com/help/help_3_2.html)",
       "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36; 360Spider"
     ],
-    "description": "360 search engine web crawler bot"
+    "description": "360 search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "psbot",
@@ -1479,14 +1916,20 @@
       "psbot-page (+http://www.picsearch.com/bot.html)",
       "psbot/0.1 (+http://www.picsearch.com/bot.html)"
     ],
-    "description": "PicSearch web crawler for image discovery"
+    "description": "PicSearch web crawler for image discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "InterfaxScanBot",
     "addition_date": "2014/03/31",
     "url": "http://scan-interfax.ru",
     "instances": [],
-    "description": "Interfax scan web crawler bot"
+    "description": "Interfax scan web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "CC Metadata Scaper",
@@ -1495,14 +1938,20 @@
     "instances": [
       "CC Metadata Scaper http://wiki.creativecommons.org/Metadata_Scraper"
     ],
-    "description": "Creative Commons metadata web crawler"
+    "description": "Creative Commons metadata web crawler",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "g00g1e\\.net",
     "addition_date": "2014/04/01",
     "url": "http://www.g00g1e.net/",
     "instances": [],
-    "description": "G00g1e web crawler for content discovery"
+    "description": "G00g1e web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "GrapeshotCrawler",
@@ -1511,7 +1960,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; GrapeshotCrawler/2.0; +http://www.grapeshot.co.uk/crawler.php)"
     ],
-    "description": "Grapeshot web crawler for content analysis"
+    "description": "Grapeshot web crawler for content analysis",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "urlappendbot",
@@ -1520,13 +1972,19 @@
     "instances": [
       "Mozilla/5.0 (compatible; URLAppendBot/1.0; +http://www.profound.net/urlappendbot.html)"
     ],
-    "description": "URL Append web crawler for analysis"
+    "description": "URL Append web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "brainobot",
     "addition_date": "2014/06/24",
     "instances": [],
-    "description": "Braino web crawler for content discovery"
+    "description": "Braino web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "fr-crawler",
@@ -1534,7 +1992,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; fr-crawler/1.1)"
     ],
-    "description": "FR Crawler web crawler for content discovery"
+    "description": "FR Crawler web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "binlar",
@@ -1546,7 +2007,10 @@
       "binlar_2.6.3 phanendra_kalapala@McAfee.com",
       "binlar_2.6.3 test@mgmt.mic"
     ],
-    "description": "Binlar web crawler for content discovery"
+    "description": "Binlar web crawler for content discovery",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "SimpleCrawler",
@@ -1554,7 +2018,10 @@
     "instances": [
       "SimpleCrawler/0.1"
     ],
-    "description": "Simple Crawler web crawler framework"
+    "description": "Simple Crawler web crawler framework",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Twitterbot",
@@ -1564,7 +2031,10 @@
       "Twitterbot/0.1",
       "Twitterbot/1.0"
     ],
-    "description": "Twitter web crawler for link previews"
+    "description": "Twitter web crawler for link previews",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "cXensebot",
@@ -1573,7 +2043,10 @@
       "cXensebot/1.1a"
     ],
     "url": "http://www.cxense.com/bot.html",
-    "description": "CXense web crawler for content analysis"
+    "description": "CXense web crawler for content analysis",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "smtbot",
@@ -1586,7 +2059,10 @@
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.75 Safari/537.36 (compatible; SMTBot/1.0; http://www.similartech.com/smtbot)"
     ],
     "url": "http://www.similartech.com/smtbot",
-    "description": "SimilarTech web crawler for technology detection"
+    "description": "SimilarTech web crawler for technology detection",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "bnf\\.fr_bot",
@@ -1596,7 +2072,10 @@
       "Mozilla/5.0 (compatible; bnf.fr_bot; +http://bibnum.bnf.fr/robot/bnf.html)",
       "Mozilla/5.0 (compatible; bnf.fr_bot; +http://www.bnf.fr/fr/outils/a.dl_web_capture_robot.html)"
     ],
-    "description": "BNF French National Library web crawler"
+    "description": "BNF French National Library web crawler",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "A6-Indexer",
@@ -1605,7 +2084,10 @@
     "instances": [
       "A6-Indexer"
     ],
-    "description": "A6 Corporation web crawler for indexing"
+    "description": "A6 Corporation web crawler for indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "ADmantX",
@@ -1614,7 +2096,10 @@
     "instances": [
       "ADmantX Platform Semantic Analyzer - ADmantX Inc. - www.admantx.com - support@admantx.com"
     ],
-    "description": "ADmantX semantic analyzer web crawler"
+    "description": "ADmantX semantic analyzer web crawler",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Facebot",
@@ -1623,7 +2108,10 @@
     "instances": [
       "Facebot/1.0"
     ],
-    "description": "Facebook's web crawler for social sharing"
+    "description": "Facebook's web crawler for social sharing",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "OrangeBot\\/",
@@ -1631,7 +2119,10 @@
       "Mozilla/5.0 (compatible; OrangeBot/2.0; support.orangebot@orange.com"
     ],
     "addition_date": "2015/01/12",
-    "description": "Orange search engine web crawler bot"
+    "description": "Orange search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "memorybot",
@@ -1640,7 +2131,10 @@
       "Mozilla/5.0 (compatible; memorybot/1.21.14 +http://mignify.com/bot.html)"
     ],
     "addition_date": "2015/02/01",
-    "description": "Mignify memory web crawler bot"
+    "description": "Mignify memory web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AdvBot",
@@ -1649,7 +2143,10 @@
       "Mozilla/5.0 (compatible; AdvBot/2.0; +http://advbot.net/bot.html)"
     ],
     "addition_date": "2015/02/01",
-    "description": "AdvBot web crawler for advertising analysis"
+    "description": "AdvBot web crawler for advertising analysis",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "MegaIndex",
@@ -1659,7 +2156,10 @@
       "Mozilla/5.0 (compatible; MegaIndex.ru/2.0; +http://megaindex.com/crawler)"
     ],
     "addition_date": "2015/03/28",
-    "description": "MegaIndex SEO tool web crawler for analysis"
+    "description": "MegaIndex SEO tool web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SemanticScholarBot",
@@ -1669,7 +2169,10 @@
       "Mozilla/5.0 (compatible) SemanticScholarBot (+https://www.semanticscholar.org/crawler)"
     ],
     "addition_date": "2015/03/28",
-    "description": "Semantic Scholar web crawler for academic content"
+    "description": "Semantic Scholar web crawler for academic content",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "ltx71",
@@ -1678,7 +2181,10 @@
       "ltx71 - (http://ltx71.com/)"
     ],
     "addition_date": "2015/04/04",
-    "description": "LTX71 web crawler for content discovery"
+    "description": "LTX71 web crawler for content discovery",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "nerdybot",
@@ -1687,7 +2193,10 @@
       "nerdybot"
     ],
     "addition_date": "2015/04/05",
-    "description": "NerdyBot web crawler for content analysis"
+    "description": "NerdyBot web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "xovibot",
@@ -1696,7 +2205,10 @@
       "Mozilla/5.0 (compatible; XoviBot/2.0; +http://www.xovibot.net/)"
     ],
     "addition_date": "2015/04/05",
-    "description": "Xovi SEO tool web crawler for analysis"
+    "description": "Xovi SEO tool web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BUbiNG",
@@ -1705,7 +2217,10 @@
       "BUbiNG (+http://law.di.unimi.it/BUbiNG.html)"
     ],
     "addition_date": "2015/04/06",
-    "description": "BUbiNG web crawler framework for research"
+    "description": "BUbiNG web crawler framework for research",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "Qwantify",
@@ -1717,7 +2232,10 @@
       "Mozilla/5.0 (compatible; Qwantify/Bleriot/1.2.1; +https://help.qwant.com/bot)"
     ],
     "addition_date": "2015/04/06",
-    "description": "Qwant search engine web crawler bot"
+    "description": "Qwant search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "archive\\.org_bot",
@@ -1734,7 +2252,10 @@
       "Mozilla/5.0 (compatible; special_archiver/3.1.1 +http://www.archive.org/details/archive.org_bot)"
     ],
     "addition_date": "2015/04/14",
-    "description": "Archive.org web crawler for preservation"
+    "description": "Archive.org web crawler for preservation",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "Applebot",
@@ -1747,7 +2268,10 @@
       "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Applebot/0.3; +http://www.apple.com/go/applebot)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4 (Applebot/0.1; +http://www.apple.com/go/applebot)"
     ],
-    "description": "Apple's web crawler for Siri and search"
+    "description": "Apple's web crawler for Siri and search",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "TweetmemeBot",
@@ -1756,7 +2280,10 @@
       "Mozilla/5.0 (TweetmemeBot/4.0; +http://datasift.com/bot.html) Gecko/20100101 Firefox/31.0"
     ],
     "addition_date": "2015/04/15",
-    "description": "TweetMeme web crawler for social content"
+    "description": "TweetMeme web crawler for social content",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "crawler4j",
@@ -1766,7 +2293,10 @@
       "crawler4j (https://github.com/yasserg/crawler4j/)"
     ],
     "addition_date": "2015/05/07",
-    "description": "Crawler4j Java web crawler framework"
+    "description": "Crawler4j Java web crawler framework",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "findxbot",
@@ -1775,7 +2305,10 @@
       "Mozilla/5.0 (compatible; Findxbot/1.0; +http://www.findxbot.com)"
     ],
     "addition_date": "2015/05/07",
-    "description": "FindX web crawler for content discovery"
+    "description": "FindX web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "S[eE][mM]rushBot",
@@ -1791,7 +2324,10 @@
       "SEMrushBot"
     ],
     "addition_date": "2015/05/26",
-    "description": "Semrush SEO tool web crawler for analysis"
+    "description": "Semrush SEO tool web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "yoozBot",
@@ -1800,7 +2336,10 @@
       "Mozilla/5.0 (compatible; yoozBot-2.2; http://yooz.ir; info@yooz.ir)"
     ],
     "addition_date": "2015/05/26",
-    "description": "Yooz web crawler for content analysis"
+    "description": "Yooz web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "lipperhey",
@@ -1812,7 +2351,10 @@
       "Mozilla/5.0 (compatible; Lipperhey-Kaus-Australis/5.0; +https://www.lipperhey.com/en/about/)"
     ],
     "addition_date": "2015/08/26",
-    "description": "Lipperhey SEO tool web crawler for analysis"
+    "description": "Lipperhey SEO tool web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Y!J",
@@ -1826,7 +2368,10 @@
       "Mozilla/5.0 (compatible; Y!J SearchMonkey/1.0 (Y!J-AGENT; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html))"
     ],
     "addition_date": "2015/05/26",
-    "description": "Yahoo Japan search engine web crawler bot"
+    "description": "Yahoo Japan search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Domain Re-Animator Bot",
@@ -1835,7 +2380,10 @@
       "Domain Re-Animator Bot (http://domainreanimator.com) - support@domainreanimator.com"
     ],
     "addition_date": "2015/04/14",
-    "description": "Domain Re-Animator web crawler for domain analysis"
+    "description": "Domain Re-Animator web crawler for domain analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AddThis",
@@ -1844,7 +2392,10 @@
       "AddThis.com robot tech.support@clearspring.com"
     ],
     "addition_date": "2015/06/02",
-    "description": "AddThis social sharing web crawler bot"
+    "description": "AddThis social sharing web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Screaming Frog SEO Spider",
@@ -1853,7 +2404,10 @@
       "Screaming Frog SEO Spider/5.1"
     ],
     "addition_date": "2016/01/08",
-    "description": "Screaming Frog SEO tool web crawler"
+    "description": "Screaming Frog SEO tool web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "MetaURI",
@@ -1862,7 +2416,10 @@
       "MetaURI API/2.0 +metauri.com"
     ],
     "addition_date": "2016/01/02",
-    "description": "MetaURI API web crawler for metadata"
+    "description": "MetaURI API web crawler for metadata",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Scrapy",
@@ -1871,7 +2428,10 @@
       "Scrapy/1.0.3 (+http://scrapy.org)"
     ],
     "addition_date": "2016/01/02",
-    "description": "Scrapy Python web crawler framework"
+    "description": "Scrapy Python web crawler framework",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Livelap[bB]ot",
@@ -1881,7 +2441,10 @@
       "Livelapbot/0.1"
     ],
     "addition_date": "2016/01/02",
-    "description": "Livelap web crawler for content discovery"
+    "description": "Livelap web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "OpenHoseBot",
@@ -1890,7 +2453,10 @@
       "Mozilla/5.0 (compatible; OpenHoseBot/2.1; +http://www.openhose.org/bot.html)"
     ],
     "addition_date": "2016/01/02",
-    "description": "OpenHose web crawler for content analysis"
+    "description": "OpenHose web crawler for content analysis",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "CapsuleChecker",
@@ -1899,7 +2465,10 @@
       "CapsuleChecker (http://www.capsulink.com/)"
     ],
     "addition_date": "2016/01/02",
-    "description": "Capsule web crawler for link checking"
+    "description": "Capsule web crawler for link checking",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "collection@infegy\\.com",
@@ -1908,7 +2477,10 @@
       "Mozilla/5.0 (compatible) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36 collection@infegy.com"
     ],
     "addition_date": "2016/01/03",
-    "description": "Infegy web crawler for social listening"
+    "description": "Infegy web crawler for social listening",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "IstellaBot",
@@ -1917,7 +2489,10 @@
       "Mozilla/5.0 (compatible; IstellaBot/1.23.15 +http://www.tiscali.it/)"
     ],
     "addition_date": "2016/01/09",
-    "description": "Istella web crawler for search indexing"
+    "description": "Istella web crawler for search indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "DeuSu\\/",
@@ -1927,13 +2502,19 @@
       "Mozilla/5.0 (compatible; DeuSu/0.1.0; +https://deusu.org)",
       "Mozilla/5.0 (compatible; DeuSu/5.0.2; +https://deusu.de/robot.html)"
     ],
-    "description": "DeuSu web crawler for search indexing"
+    "description": "DeuSu web crawler for search indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "betaBot",
     "addition_date": "2016/01/23",
     "instances": [],
-    "description": "BetaBot web crawler for testing"
+    "description": "BetaBot web crawler for testing",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Cliqzbot\\/",
@@ -1946,7 +2527,10 @@
       "Mozilla/5.0 (compatible; Cliqzbot/0.1 +http://cliqz.com/company/cliqzbot)",
       "Mozilla/5.0 (compatible; Cliqzbot/1.0 +http://cliqz.com/company/cliqzbot)"
     ],
-    "description": "Cliqz search engine web crawler bot"
+    "description": "Cliqz search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "MojeekBot\\/",
@@ -1960,7 +2544,10 @@
       "Mozilla/5.0 (compatible; MojeekBot/0.6; +https://www.mojeek.com/bot.html)",
       "Mozilla/5.0 (compatible; MojeekBot/0.6; http://www.mojeek.com/bot.html)"
     ],
-    "description": "Mojeek search engine web crawler bot"
+    "description": "Mojeek search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "netEstate NE Crawler",
@@ -1970,7 +2557,10 @@
       "netEstate NE Crawler (+http://www.sengine.info/)",
       "netEstate NE Crawler (+http://www.website-datenbank.de/)"
     ],
-    "description": "NetEstate web crawler for domain analysis"
+    "description": "NetEstate web crawler for domain analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SafeSearch microdata crawler",
@@ -1979,7 +2569,10 @@
     "instances": [
       "SafeSearch microdata crawler (https://safesearch.avira.com, safesearch-abuse@avira.com)"
     ],
-    "description": "Avira SafeSearch web crawler for safety"
+    "description": "Avira SafeSearch web crawler for safety",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Gluten Free Crawler\\/",
@@ -1988,7 +2581,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Gluten Free Crawler/1.0; +http://glutenfreepleasure.com/)"
     ],
-    "description": "Gluten Free Pleasure web crawler bot"
+    "description": "Gluten Free Pleasure web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Sonic",
@@ -1999,7 +2595,10 @@
       "Mozilla/5.0 (compatible; Sonic/1.0; http://www.yama.info.waseda.ac.jp/~crawler/info.html)",
       "Mozzila/5.0 (compatible; Sonic/1.0; http://www.yama.info.waseda.ac.jp/~crawler/info.html)"
     ],
-    "description": "Sonic web crawler for ranking analysis"
+    "description": "Sonic web crawler for ranking analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Sysomos",
@@ -2008,14 +2607,20 @@
     "instances": [
       "Mozilla/5.0 (compatible; Sysomos/1.0; +http://www.sysomos.com/; Sysomos)"
     ],
-    "description": "Sysomos web crawler for social media analysis"
+    "description": "Sysomos web crawler for social media analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Trove",
     "addition_date": "2016/02/08",
     "url": "http://www.trove.com",
     "instances": [],
-    "description": "Trove web crawler for content discovery"
+    "description": "Trove web crawler for content discovery",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "deadlinkchecker",
@@ -2026,7 +2631,10 @@
       "www.deadlinkchecker.com XMLHTTP/1.0",
       "www.deadlinkchecker.com XMLHTTP/1.0 Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.86 Safari/537.36"
     ],
-    "description": "Dead Link Checker web crawler for link validation"
+    "description": "Dead Link Checker web crawler for link validation",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Slack-ImgProxy",
@@ -2040,7 +2648,10 @@
       "Slack-ImgProxy 1.138 (+https://api.slack.com/robots)",
       "Slack-ImgProxy 149 (+https://api.slack.com/robots)"
     ],
-    "description": "Slack's image proxy web crawler bot"
+    "description": "Slack's image proxy web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Embedly",
@@ -2051,7 +2662,10 @@
       "Mozilla/5.0 (compatible; Embedly/0.2; +http://support.embed.ly/)",
       "Mozilla/5.0 (compatible; Embedly/0.2; snap; +http://support.embed.ly/)"
     ],
-    "description": "Embedly web crawler for content embedding"
+    "description": "Embedly web crawler for content embedding",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "RankActiveLinkBot",
@@ -2060,7 +2674,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; RankActiveLinkBot; +https://rankactive.com/resources/rankactive-linkbot)"
     ],
-    "description": "RankActive web crawler for link analysis"
+    "description": "RankActive web crawler for link analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "iskanie",
@@ -2069,7 +2686,10 @@
     "instances": [
       "iskanie (+http://www.iskanie.com)"
     ],
-    "description": "Iskanie web crawler for content discovery"
+    "description": "Iskanie web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SafeDNSBot",
@@ -2078,7 +2698,10 @@
     "instances": [
       "SafeDNSBot (https://www.safedns.com/searchbot)"
     ],
-    "description": "SafeDNS web crawler for security analysis"
+    "description": "SafeDNS web crawler for security analysis",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "SkypeUriPreview",
@@ -2086,7 +2709,10 @@
     "instances": [
       "Mozilla/5.0 (Windows NT 6.1; WOW64) SkypeUriPreview Preview/0.5"
     ],
-    "description": "Skype's URI preview web crawler bot"
+    "description": "Skype's URI preview web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Veoozbot",
@@ -2095,7 +2721,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Veoozbot/1.0; +http://www.veooz.com/veoozbot.html)"
     ],
-    "description": "Veooz web crawler for marketing analysis"
+    "description": "Veooz web crawler for marketing analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Slackbot",
@@ -2106,7 +2735,10 @@
       "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)",
       "Slackbot 1.0 (+https://api.slack.com/robots)"
     ],
-    "description": "Slack's link expansion web crawler bot"
+    "description": "Slack's link expansion web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "redditbot",
@@ -2115,7 +2747,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; redditbot/1.0; +http://www.reddit.com/feedback)"
     ],
-    "description": "Reddit's web crawler for content sharing"
+    "description": "Reddit's web crawler for content sharing",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "datagnionbot",
@@ -2124,7 +2759,10 @@
     "instances": [
       "datagnionbot (+http://www.datagnion.com/bot.html)"
     ],
-    "description": "Datagnion web crawler for data analysis"
+    "description": "Datagnion web crawler for data analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Google-Adwords-Instant",
@@ -2133,7 +2771,10 @@
     "instances": [
       "Google-Adwords-Instant (+http://www.google.com/adsbot.html)"
     ],
-    "description": "Google AdWords instant web crawler bot"
+    "description": "Google AdWords instant web crawler bot",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "adbeat_bot",
@@ -2142,7 +2783,10 @@
       "Mozilla/5.0 (compatible; adbeat_bot; +support@adbeat.com; support@adbeat.com)",
       "adbeat_bot"
     ],
-    "description": "AdBeat web crawler for advertising analysis"
+    "description": "AdBeat web crawler for advertising analysis",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "WhatsApp",
@@ -2175,7 +2819,10 @@
       "WhatsApp/2.19.308 A",
       "WhatsApp/2.19.330 A"
     ],
-    "description": "WhatsApp's web crawler for link previews"
+    "description": "WhatsApp's web crawler for link previews",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "contxbot",
@@ -2183,7 +2830,10 @@
     "instances": [
       "Mozilla/5.0 (compatible;contxbot/1.0)"
     ],
-    "description": "Contx web crawler for content discovery"
+    "description": "Contx web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "pinterest\\.com\\/bot",
@@ -2193,7 +2843,10 @@
       "Pinterest/0.2 (+http://www.pinterest.com/bot.html)"
     ],
     "url": "http://www.pinterest.com/bot.html",
-    "description": "Pinterest web crawler for content discovery"
+    "description": "Pinterest web crawler for content discovery",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "electricmonk",
@@ -2202,7 +2855,10 @@
       "Mozilla/5.0 (compatible; electricmonk/3.2.0 +https://www.duedil.com/our-crawler/)"
     ],
     "url": "https://www.duedil.com/our-crawler/",
-    "description": "DueDil electricmonk web crawler bot"
+    "description": "DueDil electricmonk web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "GarlikCrawler",
@@ -2211,7 +2867,10 @@
       "GarlikCrawler/1.2 (http://garlik.com/, crawler@garlik.com)"
     ],
     "url": "http://garlik.com/",
-    "description": "Garlik web crawler for content discovery"
+    "description": "Garlik web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BingPreview\\/",
@@ -2224,7 +2883,10 @@
       "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0;  WOW64;  Trident/5.0;  BingPreview/1.0b)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 BingPreview/1.0b"
     ],
-    "description": "Bing preview web crawler bot"
+    "description": "Bing preview web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "vebidoobot",
@@ -2233,7 +2895,10 @@
       "Mozilla/5.0 (compatible; vebidoobot/1.0; +https://blog.vebidoo.de/vebidoobot/"
     ],
     "url": "https://blog.vebidoo.de/vebidoobot/",
-    "description": "Vebidoo web crawler for content discovery"
+    "description": "Vebidoo web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "FemtosearchBot",
@@ -2242,7 +2907,10 @@
       "Mozilla/5.0 (compatible; FemtosearchBot/1.0; http://femtosearch.com)"
     ],
     "url": "http://femtosearch.com",
-    "description": "Femtosearch web crawler for content discovery"
+    "description": "Femtosearch web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Yahoo Link Preview",
@@ -2251,7 +2919,10 @@
       "Mozilla/5.0 (compatible; Yahoo Link Preview; https://help.yahoo.com/kb/mail/yahoo-link-preview-SLN23615.html)"
     ],
     "url": "https://help.yahoo.com/kb/mail/yahoo-link-preview-SLN23615.html",
-    "description": "Yahoo link preview web crawler bot"
+    "description": "Yahoo link preview web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "MetaJobBot",
@@ -2260,7 +2931,10 @@
       "Mozilla/5.0 (compatible; MetaJobBot; http://www.metajob.de/crawler)"
     ],
     "url": "http://www.metajob.de/the/crawler",
-    "description": "MetaJob web crawler for job discovery"
+    "description": "MetaJob web crawler for job discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "DomainStatsBot",
@@ -2269,7 +2943,10 @@
       "DomainStatsBot/1.0 (http://domainstats.io/our-bot)"
     ],
     "url": "http://domainstats.io/our-bot",
-    "description": "DomainStats web crawler for domain analysis"
+    "description": "DomainStats web crawler for domain analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "mindUpBot",
@@ -2278,7 +2955,10 @@
       "mindUpBot (datenbutler.de)"
     ],
     "url": "http://www.datenbutler.de/",
-    "description": "MindUp web crawler for content discovery"
+    "description": "MindUp web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Daum\\/",
@@ -2287,7 +2967,10 @@
       "Mozilla/5.0 (compatible; Daum/4.1; +http://cs.daum.net/faq/15/4118.html?faqId=28966)"
     ],
     "url": "http://cs.daum.net/faq/15/4118.html?faqId=28966",
-    "description": "Daum search engine web crawler bot"
+    "description": "Daum search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Jugendschutzprogramm-Crawler",
@@ -2296,7 +2979,10 @@
       "Jugendschutzprogramm-Crawler; Info: http://www.jugendschutzprogramm.de"
     ],
     "url": "http://www.jugendschutzprogramm.de",
-    "description": "Jugendschutzprogramm web crawler bot"
+    "description": "Jugendschutzprogramm web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Xenu Link Sleuth",
@@ -2305,7 +2991,10 @@
       "Xenu Link Sleuth/1.3.8"
     ],
     "url": "http://home.snafu.de/tilman/xenulink.html",
-    "description": "Xenu link checker web crawler tool"
+    "description": "Xenu link checker web crawler tool",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Pcore-HTTP",
@@ -2315,7 +3004,10 @@
       "Pcore-HTTP/v0.44.0"
     ],
     "url": "https://bitbucket.org/softvisio/pcore/overview",
-    "description": "Pcore HTTP web crawler library"
+    "description": "Pcore HTTP web crawler library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "moatbot",
@@ -2325,7 +3017,10 @@
       "Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d Safari/600.1.4 moatbot"
     ],
     "url": "https://moat.com",
-    "description": "Moat web crawler for advertising analysis"
+    "description": "Moat web crawler for advertising analysis",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "KosmioBot",
@@ -2334,7 +3029,10 @@
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.125 Safari/537.36 (compatible; KosmioBot/1.0; +http://kosm.io/bot.html)"
     ],
     "url": "http://kosm.io/bot.html",
-    "description": "Kosmio web crawler for content discovery"
+    "description": "Kosmio web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "[pP]ingdom",
@@ -2351,7 +3049,10 @@
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/61.0.3163.100 Chrome/61.0.3163.100 Safari/537.36 PingdomPageSpeed/1.0 (pingbot/2.0; http://www.pingdom.com/)"
     ],
     "url": "http://www.pingdom.com",
-    "description": "Pingdom website monitoring web crawler"
+    "description": "Pingdom website monitoring web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "AppInsights",
@@ -2360,7 +3061,10 @@
       "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; AppInsights)"
     ],
     "url": "https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview",
-    "description": "Microsoft AppInsights web crawler bot"
+    "description": "Microsoft AppInsights web crawler bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "PhantomJS",
@@ -2369,7 +3073,10 @@
       "Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1 bl.uk_lddc_renderbot/2.0.0 (+ http://www.bl.uk/aboutus/legaldeposit/websites/websites/faqswebmaster/index.html)"
     ],
     "url": "http://phantomjs.org/",
-    "description": "PhantomJS headless browser web crawler"
+    "description": "PhantomJS headless browser web crawler",
+    "tags": [
+      "browser-automation"
+    ]
   },
   {
     "pattern": "Gowikibot",
@@ -2378,7 +3085,10 @@
       "Mozilla/5.0 (compatible; Gowikibot/1.0; +http://www.gowikibot.com)"
     ],
     "url": "http://www.gowikibot.com",
-    "description": "GoWiki web crawler for content discovery"
+    "description": "GoWiki web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "PiplBot",
@@ -2388,7 +3098,10 @@
       "Mozilla/5.0+(compatible;+PiplBot;+http://www.pipl.com/bot/)"
     ],
     "url": "http://www.pipl.com/bot/",
-    "description": "Pipl web crawler for people search"
+    "description": "Pipl web crawler for people search",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Discordbot",
@@ -2397,7 +3110,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
     ],
-    "description": "Discord web crawler for link previews"
+    "description": "Discord web crawler for link previews",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "TelegramBot",
@@ -2405,7 +3121,10 @@
     "instances": [
       "TelegramBot (like TwitterBot)"
     ],
-    "description": "Telegram web crawler for link previews"
+    "description": "Telegram web crawler for link previews",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Jetslide",
@@ -2414,7 +3133,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Jetslide; +http://jetsli.de/crawler)"
     ],
-    "description": "Jetslide web crawler for content discovery"
+    "description": "Jetslide web crawler for content discovery",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "newsharecounts",
@@ -2423,7 +3145,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; NewShareCounts.com/1.0; +http://newsharecounts.com/crawler)"
     ],
-    "description": "NewShareCounts web crawler for sharing"
+    "description": "NewShareCounts web crawler for sharing",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "James BOT",
@@ -2432,7 +3157,10 @@
     "instances": [
       "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.6) Gecko/20070725 Firefox/2.0.0.6 - James BOT - WebCrawler http://cognitiveseo.com/bot.html"
     ],
-    "description": "CognitiveSEO James web crawler bot"
+    "description": "CognitiveSEO James web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Bark[rR]owler",
@@ -2444,7 +3172,10 @@
       "BarkRowler/0.7 (+http://www.exensa.com/crawling)",
       "Barkrowler/0.9 (+http://www.exensa.com/crawl)"
     ],
-    "description": "Barkrowler web crawler for content discovery"
+    "description": "Barkrowler web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "TinEye",
@@ -2454,7 +3185,10 @@
       "Mozilla/5.0 (compatible; TinEye-bot/1.31; +http://www.tineye.com/crawler.html)",
       "TinEye/1.1 (http://tineye.com/crawler.html)"
     ],
-    "description": "TinEye reverse image search web crawler"
+    "description": "TinEye reverse image search web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SocialRankIOBot",
@@ -2463,7 +3197,10 @@
     "instances": [
       "SocialRankIOBot; http://socialrank.io/about"
     ],
-    "description": "SocialRank web crawler for social analysis"
+    "description": "SocialRank web crawler for social analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "trendictionbot",
@@ -2473,7 +3210,10 @@
       "Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.0; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20071127 Firefox/3.0.0.11",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20170101 Firefox/67.0"
     ],
-    "description": "Trendiction web crawler for trend analysis"
+    "description": "Trendiction web crawler for trend analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Ocarinabot",
@@ -2481,7 +3221,10 @@
     "instances": [
       "Ocarinabot"
     ],
-    "description": "Ocarina web crawler for content discovery"
+    "description": "Ocarina web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "epicbot",
@@ -2490,7 +3233,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; epicbot; +http://www.epictions.com/epicbot)"
     ],
-    "description": "Epic web crawler for content discovery"
+    "description": "Epic web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Primalbot",
@@ -2499,7 +3245,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Primalbot; +https://www.primal.com;)"
     ],
-    "description": "Primal web crawler for content discovery"
+    "description": "Primal web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "DuckDuckGo-Favicons-Bot",
@@ -2508,7 +3257,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; DuckDuckGo-Favicons-Bot/1.0; +http://duckduckgo.com)"
     ],
-    "description": "DuckDuckGo favicon web crawler bot"
+    "description": "DuckDuckGo favicon web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "GnowitNewsbot",
@@ -2517,7 +3269,10 @@
     "instances": [
       "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0 / GnowitNewsbot / Contact information at http://www.gnowit.com"
     ],
-    "description": "Gnowit news web crawler bot"
+    "description": "Gnowit news web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Leikibot",
@@ -2526,7 +3281,10 @@
     "instances": [
       "Mozilla/5.0 (Windows NT 6.3;compatible; Leikibot/1.0; +http://www.leiki.com)"
     ],
-    "description": "Leiki web crawler for content discovery"
+    "description": "Leiki web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "LinkArchiver",
@@ -2535,7 +3293,10 @@
     "instances": [
       "@LinkArchiver twitter bot"
     ],
-    "description": "LinkArchiver web crawler for archiving"
+    "description": "LinkArchiver web crawler for archiving",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "YaK\\/",
@@ -2544,7 +3305,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; YaK/1.0; http://linkfluence.com/; bot@linkfluence.com)"
     ],
-    "description": "Linkfluence YaK web crawler bot"
+    "description": "Linkfluence YaK web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "PaperLiBot",
@@ -2554,7 +3318,10 @@
       "Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)",
       "Mozilla/5.0 (compatible; PaperLiBot/2.1; https://support.paper.li/entries/20023257-what-is-paper-li)"
     ],
-    "description": "Paper.li web crawler for content curation"
+    "description": "Paper.li web crawler for content curation",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Digg Deeper",
@@ -2563,7 +3330,10 @@
     "instances": [
       "Digg Deeper/v1 (http://digg.com/about)"
     ],
-    "description": "Digg web crawler for content discovery"
+    "description": "Digg web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "dcrawl",
@@ -2572,7 +3342,10 @@
     "instances": [
       "dcrawl/1.0"
     ],
-    "description": "dcrawl web crawler framework"
+    "description": "dcrawl web crawler framework",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Snacktory",
@@ -2581,7 +3354,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Snacktory; +https://github.com/karussell/snacktory)"
     ],
-    "description": "Snacktory web crawler for content extraction"
+    "description": "Snacktory web crawler for content extraction",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AndersPinkBot",
@@ -2590,7 +3366,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; AndersPinkBot/1.0; +http://anderspink.com/bot.html)"
     ],
-    "description": "AndersPink web crawler for content discovery"
+    "description": "AndersPink web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Fyrebot",
@@ -2598,7 +3377,10 @@
     "instances": [
       "Fyrebot/1.0"
     ],
-    "description": "Fyre web crawler for content discovery"
+    "description": "Fyre web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "EveryoneSocialBot",
@@ -2607,7 +3389,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; EveryoneSocialBot/1.0; support@everyonesocial.com http://everyonesocial.com/)"
     ],
-    "description": "EveryoneSocial web crawler for sharing"
+    "description": "EveryoneSocial web crawler for sharing",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Mediatoolkitbot",
@@ -2616,7 +3401,10 @@
     "instances": [
       "Mediatoolkitbot (complaints@mediatoolkit.com)"
     ],
-    "description": "Mediatoolkit web crawler for monitoring"
+    "description": "Mediatoolkit web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Luminator-robots",
@@ -2624,7 +3412,10 @@
     "instances": [
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.13 (KHTML, like Gecko) Chrome/30.0.1599.66 Safari/537.13 Luminator-robots/2.0"
     ],
-    "description": "Luminator web crawler for content discovery"
+    "description": "Luminator web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "ExtLinksBot",
@@ -2633,7 +3424,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; ExtLinksBot/1.5 +https://extlinks.com/Bot.html)"
     ],
-    "description": "ExtLinks web crawler for link analysis"
+    "description": "ExtLinks web crawler for link analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SurveyBot",
@@ -2641,7 +3435,10 @@
     "instances": [
       "Mozilla/5.0 (Windows; U; Windows NT 5.1; en; rv:1.9.0.13) Gecko/2009073022 Firefox/3.5.2 (.NET CLR 3.5.30729) SurveyBot/2.3 (DomainTools)"
     ],
-    "description": "DomainTools survey web crawler bot"
+    "description": "DomainTools survey web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "NING\\/",
@@ -2649,7 +3446,10 @@
     "instances": [
       "NING/1.0"
     ],
-    "description": "Ning web crawler for content discovery"
+    "description": "Ning web crawler for content discovery",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "okhttp",
@@ -2661,7 +3461,10 @@
       "okhttp/3.5.0",
       "okhttp/4.1.0"
     ],
-    "description": "OkHttp Java HTTP client library"
+    "description": "OkHttp Java HTTP client library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Nuzzel",
@@ -2669,7 +3472,10 @@
     "instances": [
       "Nuzzel"
     ],
-    "description": "Nuzzel web crawler for news discovery"
+    "description": "Nuzzel web crawler for news discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "omgili",
@@ -2678,7 +3484,10 @@
     "instances": [
       "omgili/0.5 +http://omgili.com"
     ],
-    "description": "Omgili web crawler for content discovery"
+    "description": "Omgili web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "PocketParser",
@@ -2687,7 +3496,10 @@
     "instances": [
       "PocketParser/2.0 (+https://getpocket.com/pocketparser_ua)"
     ],
-    "description": "Pocket web crawler for content parsing"
+    "description": "Pocket web crawler for content parsing",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "YisouSpider",
@@ -2696,7 +3508,10 @@
       "YisouSpider",
       "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 YisouSpider/5.0 Safari/537.36"
     ],
-    "description": "Yisou search engine web crawler bot"
+    "description": "Yisou search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "um-LN",
@@ -2704,7 +3519,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; um-LN/1.0; mailto: techinfo@ubermetrics-technologies.com)"
     ],
-    "description": "Ubermetrics web crawler for monitoring"
+    "description": "Ubermetrics web crawler for monitoring",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "ToutiaoSpider",
@@ -2713,7 +3531,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; ToutiaoSpider/1.0; http://web.toutiao.com/media_cooperation/;)"
     ],
-    "description": "Toutiao news platform web crawler bot"
+    "description": "Toutiao news platform web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "MuckRack",
@@ -2722,7 +3543,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; MuckRack/1.0; +http://muckrack.com)"
     ],
-    "description": "MuckRack journalist database web crawler"
+    "description": "MuckRack journalist database web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Jamie's Spider",
@@ -2731,7 +3555,10 @@
     "instances": [
       "Jamie's Spider (http://jamiembrown.com/)"
     ],
-    "description": "Jamie Brown's personal web crawler bot"
+    "description": "Jamie Brown's personal web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AHC\\/",
@@ -2740,7 +3567,10 @@
     "instances": [
       "AHC/2.0"
     ],
-    "description": "Async HTTP Client Java library for HTTP requests"
+    "description": "Async HTTP Client Java library for HTTP requests",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "NetcraftSurveyAgent",
@@ -2748,7 +3578,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; NetcraftSurveyAgent/1.0; +info@netcraft.com)"
     ],
-    "description": "Netcraft survey web crawler bot"
+    "description": "Netcraft survey web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Laserlikebot",
@@ -2756,7 +3589,10 @@
     "instances": [
       "Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4 (compatible; Laserlikebot/0.1)"
     ],
-    "description": "Laserlike web crawler for content discovery"
+    "description": "Laserlike web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "^Apache-HttpClient",
@@ -2777,7 +3613,10 @@
       "Apache-HttpClient/4.5.7 (Java/11.0.3)",
       "Apache-HttpClient/4.5.10 (Java/1.8.0_201)"
     ],
-    "description": "Apache HTTP Client Java library for requests"
+    "description": "Apache HTTP Client Java library for requests",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "AppEngine-Google",
@@ -2786,7 +3625,10 @@
       "AppEngine-Google; (+http://code.google.com/appengine; appid: example)",
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36 AppEngine-Google; (+http://code.google.com/appengine; appid: s~feedly-nikon3)"
     ],
-    "description": "Google App Engine web crawler bot"
+    "description": "Google App Engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Jetty",
@@ -2794,7 +3636,10 @@
     "instances": [
       "Jetty/9.3.z-SNAPSHOT"
     ],
-    "description": "Jetty web server HTTP client library"
+    "description": "Jetty web server HTTP client library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Upflow",
@@ -2802,7 +3647,10 @@
     "instances": [
       "Upflow/1.0"
     ],
-    "description": "Upflow web crawler for content analysis"
+    "description": "Upflow web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Thinklab",
@@ -2811,7 +3659,10 @@
     "instances": [
       "Thinklab (thinklab.com)"
     ],
-    "description": "Thinklab web crawler for research"
+    "description": "Thinklab web crawler for research",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "Traackr\\.com",
@@ -2820,7 +3671,10 @@
     "instances": [
       "Traackr.com"
     ],
-    "description": "Traackr influencer marketing web crawler"
+    "description": "Traackr influencer marketing web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Twurly",
@@ -2829,7 +3683,10 @@
     "instances": [
       "Ruby, Twurly v1.1 (http://twurly.org)"
     ],
-    "description": "Twurly Ruby web crawler framework"
+    "description": "Twurly Ruby web crawler framework",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Mastodon",
@@ -2837,7 +3694,10 @@
     "instances": [
       "http.rb/2.2.2 (Mastodon/1.5.1; +https://example-masto-instance.org/)"
     ],
-    "description": "Mastodon social network web crawler bot"
+    "description": "Mastodon social network web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "http_get",
@@ -2845,7 +3705,10 @@
     "instances": [
       "http_get"
     ],
-    "description": "HTTP GET command-line tool for requests"
+    "description": "HTTP GET command-line tool for requests",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "DnyzBot",
@@ -2853,7 +3716,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; DnyzBot/1.0)"
     ],
-    "description": "Dnyz web crawler for content discovery"
+    "description": "Dnyz web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "botify",
@@ -2861,7 +3727,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; botify; http://botify.com)"
     ],
-    "description": "Botify SEO tool web crawler for analysis"
+    "description": "Botify SEO tool web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "007ac9 Crawler",
@@ -2869,7 +3738,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; 007ac9 Crawler; http://crawler.007ac9.net/)"
     ],
-    "description": "007ac9 web crawler for content discovery"
+    "description": "007ac9 web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BehloolBot",
@@ -2877,7 +3749,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; BehloolBot/beta; +http://www.webeaver.com/bot)"
     ],
-    "description": "Behlool web crawler for content analysis"
+    "description": "Behlool web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BrandVerity",
@@ -2887,7 +3762,10 @@
       "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11A465 Twitter for iPhone BrandVerity/1.0 (http://www.brandverity.com/why-is-brandverity-visiting-me)"
     ],
     "url": "http://www.brandverity.com/why-is-brandverity-visiting-me",
-    "description": "BrandVerity web crawler for brand monitoring"
+    "description": "BrandVerity web crawler for brand monitoring",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "check_http",
@@ -2895,7 +3773,10 @@
     "instances": [
       "check_http/v2.2.1 (nagios-plugins 2.2.1)"
     ],
-    "description": "Nagios check_http monitoring plugin"
+    "description": "Nagios check_http monitoring plugin",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "BDCbot",
@@ -2904,7 +3785,10 @@
       "Mozilla/5.0 (Windows NT 6.1; compatible; BDCbot/1.0; +http://bigweb.bigdatacorp.com.br/faq.aspx) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64; BDCbot/1.0; +http://bigweb.bigdatacorp.com.br/faq.aspx) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36"
     ],
-    "description": "BigDataCorp web crawler for data collection"
+    "description": "BigDataCorp web crawler for data collection",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "ZumBot",
@@ -2912,7 +3796,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; ZumBot/1.0; http://help.zum.com/inquiry)"
     ],
-    "description": "Zum search engine web crawler bot"
+    "description": "Zum search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "EZID",
@@ -2920,7 +3807,10 @@
     "instances": [
       "EZID (EZID link checker; https://ezid.cdlib.org/)"
     ],
-    "description": "EZID link checker web crawler bot"
+    "description": "EZID link checker web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "ICC-Crawler",
@@ -2929,7 +3819,10 @@
       "ICC-Crawler/2.0 (Mozilla-compatible; ; http://ucri.nict.go.jp/en/icccrawler.html)"
     ],
     "url": "http://ucri.nict.go.jp/en/icccrawler.html",
-    "description": "ICC web crawler for language research"
+    "description": "ICC web crawler for language research",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "ArchiveBot",
@@ -2938,7 +3831,10 @@
       "ArchiveTeam ArchiveBot/20170106.02 (wpull 2.0.2)"
     ],
     "url": "https://github.com/ArchiveTeam/ArchiveBot",
-    "description": "Archive Team web crawler for preservation"
+    "description": "Archive Team web crawler for preservation",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "^LCC ",
@@ -2947,7 +3843,10 @@
       "LCC (+http://corpora.informatik.uni-leipzig.de/crawler_faq.html)"
     ],
     "url": "http://corpora.informatik.uni-leipzig.de/crawler_faq.html",
-    "description": "Leipzig Corpora Collection web crawler"
+    "description": "Leipzig Corpora Collection web crawler",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "filterdb\\.iss\\.net\\/crawler",
@@ -2956,7 +3855,10 @@
       "Mozilla/5.0 (compatible; oBot/2.3.1; +http://filterdb.iss.net/crawler/)"
     ],
     "url": "http://filterdb.iss.net/crawler/",
-    "description": "ISS filter database web crawler"
+    "description": "ISS filter database web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "BLP_bbot",
@@ -2964,7 +3866,10 @@
     "instances": [
       "BLP_bbot/0.1"
     ],
-    "description": "BLP web crawler for content discovery"
+    "description": "BLP web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BomboraBot",
@@ -2973,7 +3878,10 @@
       "Mozilla/5.0 (compatible; BomboraBot/1.0; +http://www.bombora.com/bot)"
     ],
     "url": "http://www.bombora.com/bot",
-    "description": "Bombora web crawler for business intelligence"
+    "description": "Bombora web crawler for business intelligence",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Buck\\/",
@@ -2982,7 +3890,10 @@
       "Buck/2.2; (+https://app.hypefactors.com/media-monitoring/about.html)"
     ],
     "url": "https://app.hypefactors.com/media-monitoring/about.html",
-    "description": "Hypefactors media monitoring web crawler"
+    "description": "Hypefactors media monitoring web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Companybook-Crawler",
@@ -2991,7 +3902,10 @@
       "Companybook-Crawler (+https://www.companybooknetworking.com/)"
     ],
     "url": "https://www.companybooknetworking.com/",
-    "description": "Companybook networking web crawler"
+    "description": "Companybook networking web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Genieo",
@@ -3000,7 +3914,10 @@
       "Mozilla/5.0 (compatible; Genieo/1.0 http://www.genieo.com/webfilter.html)"
     ],
     "url": "http://www.genieo.com/webfilter.html",
-    "description": "Genieo web filter web crawler bot"
+    "description": "Genieo web filter web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "magpie-crawler",
@@ -3009,7 +3926,10 @@
       "magpie-crawler/1.1 (U; Linux amd64; en-GB; +http://www.brandwatch.net)"
     ],
     "url": "http://www.brandwatch.net",
-    "description": "Brandwatch magpie web crawler bot"
+    "description": "Brandwatch magpie web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "MeltwaterNews",
@@ -3018,7 +3938,10 @@
       "MeltwaterNews www.meltwater.com"
     ],
     "url": "http://www.meltwater.com",
-    "description": "Meltwater news monitoring web crawler"
+    "description": "Meltwater news monitoring web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Moreover",
@@ -3027,7 +3950,10 @@
       "Mozilla/5.0 Moreover/5.1 (+http://www.moreover.com)"
     ],
     "url": "http://www.moreover.com",
-    "description": "Moreover news aggregation web crawler"
+    "description": "Moreover news aggregation web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "newspaper\\/",
@@ -3038,7 +3964,10 @@
       "newspaper/0.2.6",
       "newspaper/0.2.8"
     ],
-    "description": "Newspaper Python web scraping library"
+    "description": "Newspaper Python web scraping library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "ScoutJet",
@@ -3047,7 +3976,10 @@
       "Mozilla/5.0 (compatible; ScoutJet; +http://www.scoutjet.com/)"
     ],
     "url": "http://www.scoutjet.com/",
-    "description": "ScoutJet web crawler for content discovery"
+    "description": "ScoutJet web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "(^| )sentry\\/",
@@ -3056,7 +3988,10 @@
       "sentry/8.22.0 (https://sentry.io)"
     ],
     "url": "https://sentry.io",
-    "description": "Sentry error tracking web crawler bot"
+    "description": "Sentry error tracking web crawler bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "StorygizeBot",
@@ -3065,7 +4000,10 @@
       "Mozilla/5.0 (compatible; StorygizeBot; http://www.storygize.com)"
     ],
     "url": "http://www.storygize.com",
-    "description": "Storygize web crawler for content analysis"
+    "description": "Storygize web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "UptimeRobot",
@@ -3074,7 +4012,10 @@
       "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)"
     ],
     "url": "http://www.uptimerobot.com/",
-    "description": "UptimeRobot website monitoring web crawler"
+    "description": "UptimeRobot website monitoring web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "OutclicksBot",
@@ -3086,7 +4027,10 @@
       "OutclicksBot/2 +https://www.outclicks.net/agent/p2i4sNUh7eylJF1S6SGgRs5mP40ExlYvsr9GBxVQG6h"
     ],
     "url": "https://www.outclicks.net",
-    "description": "Outclicks web crawler for link tracking"
+    "description": "Outclicks web crawler for link tracking",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "seoscanners",
@@ -3095,7 +4039,10 @@
       "Mozilla/5.0 (compatible; seoscanners.net/1; +spider@seoscanners.net)"
     ],
     "url": "https://github.com/monperrus/crawler-user-agents/issues/384#issuecomment-2575367162",
-    "description": "SEO Scanners web crawler for analysis"
+    "description": "SEO Scanners web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Hatena",
@@ -3108,7 +4055,10 @@
       "HatenaBookmark/4.0 (Hatena::Bookmark; Analyzer)",
       "Hatena::Fetcher/0.01 (master) Furl/3.13"
     ],
-    "description": "Hatena web services web crawler bot"
+    "description": "Hatena web services web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Google Web Preview",
@@ -3117,7 +4067,10 @@
       "Mozilla/5.0 (Linux; U; Android 2.3.4; generic) AppleWebKit/537.36 (KHTML, like Gecko; Google Web Preview) Version/4.0 Mobile Safari/537.36",
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko; Google Web Preview) Chrome/27.0.1453 Safari/537.36"
     ],
-    "description": "Google web preview web crawler bot"
+    "description": "Google web preview web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "MauiBot",
@@ -3125,7 +4078,10 @@
     "instances": [
       "MauiBot (crawler.feedback+wc@gmail.com)"
     ],
-    "description": "Maui web crawler for content discovery"
+    "description": "Maui web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AlphaBot",
@@ -3134,7 +4090,10 @@
       "Mozilla/5.0 (compatible; AlphaBot/3.2; +http://alphaseobot.com/bot.html)"
     ],
     "url": "http://alphaseobot.com/bot.html",
-    "description": "AlphaBot SEO web crawler for analysis"
+    "description": "AlphaBot SEO web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SBL-BOT",
@@ -3143,7 +4102,10 @@
       "SBL-BOT (http://sbl.net)"
     ],
     "url": "http://sbl.net",
-    "description": "Bot of SoftByte BlackWidow"
+    "description": "Bot of SoftByte BlackWidow",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "IAS crawler",
@@ -3152,7 +4114,10 @@
       "IAS crawler (ias_crawler; http://integralads.com/site-indexing-policy/)"
     ],
     "url": "http://integralads.com/site-indexing-policy/",
-    "description": "Bot of Integral Ad Science, Inc."
+    "description": "Bot of Integral Ad Science, Inc.",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "adscanner",
@@ -3160,7 +4125,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; adscanner/)"
     ],
-    "description": "AdScanner web crawler for ad analysis"
+    "description": "AdScanner web crawler for ad analysis",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Netvibes",
@@ -3170,7 +4138,10 @@
       "Netvibes (crawler; http://www.netvibes.com)"
     ],
     "url": "http://www.netvibes.com",
-    "description": "Netvibes web crawler for content aggregation"
+    "description": "Netvibes web crawler for content aggregation",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "acapbot",
@@ -3179,7 +4150,10 @@
       "Mozilla/5.0 (compatible;acapbot/0.1;treat like Googlebot)",
       "Mozilla/5.0 (compatible;acapbot/0.1.;treat like Googlebot)"
     ],
-    "description": "ACAP web crawler for content analysis"
+    "description": "ACAP web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Baidu-YunGuanCe",
@@ -3192,7 +4166,10 @@
       "Baidu-YunGuanCe-VSBot(ce.baidu.com)"
     ],
     "url": "https://ce.baidu.com/topic/topic20150908",
-    "description": "Baidu Cloud Watch"
+    "description": "Baidu Cloud Watch",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "bitlybot",
@@ -3203,7 +4180,10 @@
       "bitlybot"
     ],
     "url": "http://bit.ly/",
-    "description": "Bit.ly web crawler for link tracking"
+    "description": "Bit.ly web crawler for link tracking",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "blogmuraBot",
@@ -3212,7 +4192,10 @@
       "blogmuraBot (+http://www.blogmura.com)"
     ],
     "url": "http://www.blogmura.com",
-    "description": "A blog ranking site which links to blogs on just about every theme possible."
+    "description": "A blog ranking site which links to blogs on just about every theme possible.",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Bot\\.AraTurka\\.com",
@@ -3221,7 +4204,10 @@
       "Bot.AraTurka.com/0.0.1"
     ],
     "url": "http://www.araturka.com",
-    "description": "AraTurka web crawler for content discovery"
+    "description": "AraTurka web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "bot-pge\\.chlooe\\.com",
@@ -3229,7 +4215,10 @@
     "instances": [
       "bot-pge.chlooe.com/1.0.0 (+http://www.chlooe.com/)"
     ],
-    "description": "Chlooe web crawler for content analysis"
+    "description": "Chlooe web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BoxcarBot",
@@ -3238,7 +4227,10 @@
       "Mozilla/5.0 (compatible; BoxcarBot/1.1; +awesome@boxcar.io)"
     ],
     "url": "https://boxcar.io/",
-    "description": "Boxcar web crawler for notifications"
+    "description": "Boxcar web crawler for notifications",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BTWebClient",
@@ -3247,7 +4239,10 @@
       "BTWebClient/180B(9704)"
     ],
     "url": "http://www.utorrent.com/",
-    "description": "µTorrent BitTorrent Client"
+    "description": "\u00b5Torrent BitTorrent Client",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "ContextAd Bot",
@@ -3256,7 +4251,10 @@
       "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0;.NET CLR 1.0.3705; ContextAd Bot 1.0)",
       "ContextAd Bot 1.0"
     ],
-    "description": "ContextAd web crawler for advertising"
+    "description": "ContextAd web crawler for advertising",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Digincore bot",
@@ -3265,7 +4263,10 @@
       "Mozilla/5.0 (compatible; Digincore bot; https://www.digincore.com/crawler.html for rules and instructions.)"
     ],
     "url": "http://www.digincore.com/crawler.html",
-    "description": "Digincore web crawler for content analysis"
+    "description": "Digincore web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Disqus",
@@ -3274,7 +4275,10 @@
       "Disqus/1.0"
     ],
     "url": "https://disqus.com/",
-    "description": "validate and quality check pages."
+    "description": "validate and quality check pages.",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Feedly",
@@ -3284,7 +4288,10 @@
       "FeedlyBot/1.0 (http://feedly.com)"
     ],
     "url": "https://www.feedly.com/fetcher.html",
-    "description": "Feedly Fetcher is how Feedly grabs RSS or Atom feeds when users choose to add them to their Feedly or any of the other applications built on top of the feedly cloud."
+    "description": "Feedly Fetcher is how Feedly grabs RSS or Atom feeds when users choose to add them to their Feedly or any of the other applications built on top of the feedly cloud.",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Fetch\\/",
@@ -3292,7 +4299,10 @@
     "instances": [
       "Fetch/2.0a (CMS Detection/Web/SEO analysis tool, see http://guess.scritch.org)"
     ],
-    "description": "Fetch web crawler for CMS detection"
+    "description": "Fetch web crawler for CMS detection",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Fever",
@@ -3301,7 +4311,10 @@
       "Fever/1.38 (Feed Parser; http://feedafever.com; Allow like Gecko)"
     ],
     "url": "http://feedafever.com",
-    "description": "Fever feed reader web crawler bot"
+    "description": "Fever feed reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Flamingo_SearchEngine",
@@ -3309,7 +4322,10 @@
     "instances": [
       "Flamingo_SearchEngine (+http://www.flamingosearch.com/bot)"
     ],
-    "description": "Flamingo search engine web crawler bot"
+    "description": "Flamingo search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "FlipboardProxy",
@@ -3322,7 +4338,10 @@
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:49.0) Gecko/20100101 Firefox/49.0 (FlipboardProxy/1.2; +http://flipboard.com/browserproxy)"
     ],
     "url": "https://about.flipboard.com/browserproxy/",
-    "description": "a proxy service to fetch, validate, and prepare certain elements of websites for presentation through the Flipboard Application"
+    "description": "a proxy service to fetch, validate, and prepare certain elements of websites for presentation through the Flipboard Application",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "g2reader-bot",
@@ -3331,7 +4350,10 @@
       "g2reader-bot/1.0 (+http://www.g2reader.com/)"
     ],
     "url": "http://www.g2reader.com/",
-    "description": "G2Reader web crawler for content discovery"
+    "description": "G2Reader web crawler for content discovery",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "G2 Web Services",
@@ -3340,7 +4362,10 @@
       "G2 Web Services/1.0 (built with StormCrawler Archetype 1.8; https://www.g2webservices.com/; developers@g2llc.com)"
     ],
     "url": "https://www.g2webservices.com/",
-    "description": "G2 web services web crawler bot"
+    "description": "G2 web services web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "imrbot",
@@ -3349,7 +4374,10 @@
       "Mozilla/5.0 (compatible; imrbot/1.10.8 +http://www.mignify.com)"
     ],
     "url": "http://www.mignify.com",
-    "description": "Mignify imrbot web crawler bot"
+    "description": "Mignify imrbot web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "K7MLWCBot",
@@ -3358,7 +4386,10 @@
       "K7MLWCBot/1.0 (+http://www.k7computing.com)"
     ],
     "url": "http://www.k7computing.com",
-    "description": "Virus scanner"
+    "description": "Virus scanner",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Kemvibot",
@@ -3367,7 +4398,10 @@
       "Kemvibot/1.0 (http://kemvi.com, marco@kemvi.com)"
     ],
     "url": "http://kemvi.com",
-    "description": "Kemvi web crawler for content discovery"
+    "description": "Kemvi web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Landau-Media-Spider",
@@ -3376,7 +4410,10 @@
       "Landau-Media-Spider/1.0(http://bots.landaumedia.de/bot.html)"
     ],
     "url": "http://bots.landaumedia.de/bot.html",
-    "description": "Landau Media web crawler bot"
+    "description": "Landau Media web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "linkapediabot",
@@ -3385,7 +4422,10 @@
       "linkapediabot (+http://www.linkapedia.com)"
     ],
     "url": "http://www.linkapedia.com",
-    "description": "Linkapedia web crawler for link discovery"
+    "description": "Linkapedia web crawler for link discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "vkShare",
@@ -3394,7 +4434,10 @@
       "Mozilla/5.0 (compatible; vkShare; +http://vk.com/dev/Share)"
     ],
     "url": "http://vk.com/dev/Share",
-    "description": "VK Share web crawler for social sharing"
+    "description": "VK Share web crawler for social sharing",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Siteimprove\\.com",
@@ -3405,7 +4448,10 @@
       "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0) SiteCheck-sitecrawl by Siteimprove.com",
       "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.0) LinkCheck by Siteimprove.com"
     ],
-    "description": "Siteimprove web crawler for site analysis"
+    "description": "Siteimprove web crawler for site analysis",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "BLEXBot\\/",
@@ -3414,7 +4460,10 @@
       "Mozilla/5.0 (compatible; BLEXBot/1.0; +http://webmeup-crawler.com/)"
     ],
     "url": "http://webmeup-crawler.com",
-    "description": "WebMeUp BLEX web crawler bot"
+    "description": "WebMeUp BLEX web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "DareBoost",
@@ -3423,7 +4472,10 @@
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.75 Safari/537.36 DareBoost"
     ],
     "url": "https://www.dareboost.com/",
-    "description": "Bot to test, Analyze and Optimize website"
+    "description": "Bot to test, Analyze and Optimize website",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "ZuperlistBot\\/",
@@ -3431,7 +4483,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; ZuperlistBot/1.0)"
     ],
-    "description": "Zuperlist web crawler for content discovery"
+    "description": "Zuperlist web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Miniflux\\/",
@@ -3448,7 +4503,10 @@
       "Mozilla/5.0 (compatible; Miniflux/3b6e44c; +https://miniflux.app)"
     ],
     "url": "https://miniflux.net",
-    "description": "Miniflux is a minimalist and opinionated feed reader."
+    "description": "Miniflux is a minimalist and opinionated feed reader.",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Feedspot",
@@ -3458,7 +4516,10 @@
       "Mozilla/5.0 (compatible; Feedspot/1.0 (+https://www.feedspot.com/fs/fetcher; like FeedFetcher-Google)"
     ],
     "url": "http://www.feedspot.com/fs/bot",
-    "description": "Feedspot web crawler for feed discovery"
+    "description": "Feedspot web crawler for feed discovery",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Diffbot\\/",
@@ -3467,7 +4528,10 @@
       "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729; Diffbot/0.1; +http://www.diffbot.com)"
     ],
     "url": "http://www.diffbot.com",
-    "description": "Diffbot web crawler for content extraction"
+    "description": "Diffbot web crawler for content extraction",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SEOkicks",
@@ -3476,7 +4540,10 @@
       "Mozilla/5.0 (compatible; SEOkicks; +https://www.seokicks.de/robot.html)"
     ],
     "url": "https://www.seokicks.de/robot.html",
-    "description": "SEOkicks web crawler for SEO analysis"
+    "description": "SEOkicks web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "tracemyfile",
@@ -3484,7 +4551,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; tracemyfile/1.0; +bot@tracemyfile.com)"
     ],
-    "description": "TraceMyFile web crawler for file tracking"
+    "description": "TraceMyFile web crawler for file tracking",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Nimbostratus-Bot",
@@ -3492,7 +4562,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Nimbostratus-Bot/v1.3.2; http://cloudsystemnetworks.com)"
     ],
-    "description": "Nimbostratus web crawler for cloud analysis"
+    "description": "Nimbostratus web crawler for cloud analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "zgrab",
@@ -3501,7 +4574,10 @@
       "Mozilla/5.0 zgrab/0.x"
     ],
     "url": "https://github.com/zmap/zgrab2",
-    "description": "Zgrab web crawler for security scanning"
+    "description": "Zgrab web crawler for security scanning",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "PR-CY\\.RU",
@@ -3510,7 +4586,10 @@
       "Mozilla/5.0 (compatible; PR-CY.RU; + https://a.pr-cy.ru)"
     ],
     "url": "https://a.pr-cy.ru/",
-    "description": "PR-CY web crawler for SEO analysis"
+    "description": "PR-CY web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AdsTxtCrawler",
@@ -3518,7 +4597,10 @@
     "instances": [
       "AdsTxtCrawler/1.0"
     ],
-    "description": "AdsTxt web crawler for ads.txt validation"
+    "description": "AdsTxt web crawler for ads.txt validation",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Datafeedwatch",
@@ -3527,7 +4609,10 @@
       "Datafeedwatch/2.1.x"
     ],
     "url": "https://www.datafeedwatch.com/",
-    "description": "Datafeedwatch web crawler for feed analysis"
+    "description": "Datafeedwatch web crawler for feed analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Zabbix",
@@ -3536,7 +4621,10 @@
       "Zabbix"
     ],
     "url": "https://www.zabbix.com/documentation/3.4/manual/web_monitoring",
-    "description": "Zabbix web crawler for monitoring"
+    "description": "Zabbix web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "TangibleeBot",
@@ -3545,7 +4633,10 @@
       "TangibleeBot/1.0.0.0 (http://tangiblee.com/bot)"
     ],
     "url": "http://tangiblee.com/bot",
-    "description": "Tangiblee web crawler for visual search"
+    "description": "Tangiblee web crawler for visual search",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "google-xrawler",
@@ -3554,7 +4645,10 @@
       "google-xrawler"
     ],
     "url": "https://webmasters.stackexchange.com/questions/105560/what-is-the-google-xrawler-user-agent-used-for",
-    "description": "Google xrawler web crawler bot"
+    "description": "Google xrawler web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "axios",
@@ -3564,7 +4658,10 @@
       "axios/0.19.0"
     ],
     "url": "https://github.com/axios/axios",
-    "description": "Axios HTTP client library for requests"
+    "description": "Axios HTTP client library for requests",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Amazon CloudFront",
@@ -3573,7 +4670,10 @@
       "Amazon CloudFront"
     ],
     "url": "https://aws.amazon.com/cloudfront/",
-    "description": "Amazon CloudFront web crawler bot"
+    "description": "Amazon CloudFront web crawler bot",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Pulsepoint",
@@ -3581,7 +4681,10 @@
     "instances": [
       "Pulsepoint XT3 web scraper"
     ],
-    "description": "Pulsepoint web crawler for content discovery"
+    "description": "Pulsepoint web crawler for content discovery",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "CloudFlare-AlwaysOnline",
@@ -3591,7 +4694,10 @@
       "Mozilla/5.0 (compatible; CloudFlare-AlwaysOnline/1.0; +https://www.cloudflare.com/always-online) AppleWebKit/534.34"
     ],
     "url": "https://www.cloudflare.com/always-online/",
-    "description": "CloudFlare always online web crawler"
+    "description": "CloudFlare always online web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Cloudflare-Healthchecks",
@@ -3600,7 +4706,10 @@
       "Mozilla/5.0 (compatible; Cloudflare-Healthchecks/1.0; +https://www.cloudflare.com/; healthcheck-id: AAAAAAAAAAAAAAAA)"
     ],
     "url": "https://developers.cloudflare.com/health-checks/",
-    "description": "CloudFlare health checks web crawler"
+    "description": "CloudFlare health checks web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Cloudflare-Traffic-Manager",
@@ -3609,7 +4718,10 @@
       "Mozilla/5.0 (compatible; Cloudflare-Traffic-Manager/1.0; +https://www.cloudflare.com/traffic-manager/; pool-id: AAAAAAAAAAAAAAAA)"
     ],
     "url": "https://developers.cloudflare.com/load-balancing/monitors/",
-    "description": "CloudFlare traffic manager web crawler"
+    "description": "CloudFlare traffic manager web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "CloudFlare-Prefetch",
@@ -3618,7 +4730,10 @@
       "Mozilla/5.0 (compatible; CloudFlare-Prefetch/0.1; +http://www.cloudflare.com/)"
     ],
     "url": "https://developers.cloudflare.com/speed/optimization/content/prefetch-urls/",
-    "description": "CloudFlare prefetch web crawler bot"
+    "description": "CloudFlare prefetch web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Cloudflare-SSLDetector",
@@ -3627,7 +4742,10 @@
       "Cloudflare-SSLDetector"
     ],
     "url": "https://developers.cloudflare.com/ssl/origin-configuration/ssl-tls-recommender/",
-    "description": "CloudFlare SSL detector web crawler"
+    "description": "CloudFlare SSL detector web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "https:\\/\\/developers\\.cloudflare\\.com\\/security-center\\/",
@@ -3636,7 +4754,10 @@
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36 (compatible; +https://developers.cloudflare.com/security-center/)"
     ],
     "url": "https://developers.cloudflare.com/ssl/origin-configuration/ssl-tls-recommender/",
-    "description": "CloudFlare security center web crawler"
+    "description": "CloudFlare security center web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Google-Structured-Data-Testing-Tool",
@@ -3646,7 +4767,10 @@
       "Mozilla/5.0 (compatible; Google-Structured-Data-Testing-Tool +http://developers.google.com/structured-data/testing-tool/)"
     ],
     "url": "https://search.google.com/structured-data/testing-tool",
-    "description": "Google structured data testing web crawler"
+    "description": "Google structured data testing web crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "WordupInfoSearch",
@@ -3654,7 +4778,10 @@
     "instances": [
       "WordupInfoSearch/1.0"
     ],
-    "description": "Wordup info search web crawler bot"
+    "description": "Wordup info search web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "WebDataStats",
@@ -3663,7 +4790,10 @@
       "Mozilla/5.0 (compatible; WebDataStats/1.0 ; +https://webdatastats.com/policy.html)"
     ],
     "url": "https://webdatastats.com/",
-    "description": "WebDataStats web crawler for data analysis"
+    "description": "WebDataStats web crawler for data analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "HttpUrlConnection",
@@ -3671,7 +4801,10 @@
     "instances": [
       "Jersey/2.25.1 (HttpUrlConnection 1.8.0_141)"
     ],
-    "description": "Java HttpUrlConnection HTTP client"
+    "description": "Java HttpUrlConnection HTTP client",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "ZoomBot",
@@ -3680,7 +4813,10 @@
       "ZoomBot (Linkbot 1.0 http://suite.seozoom.it/bot.html)"
     ],
     "url": "http://suite.seozoom.it/bot.html",
-    "description": "SEOZoom web crawler for SEO analysis"
+    "description": "SEOZoom web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "VelenPublicWebCrawler",
@@ -3689,7 +4825,10 @@
     "instances": [
       "VelenPublicWebCrawler (velen.io)"
     ],
-    "description": "Velen web crawler for content discovery"
+    "description": "Velen web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "MoodleBot",
@@ -3697,7 +4836,10 @@
     "instances": [
       "MoodleBot/1.0"
     ],
-    "description": "Moodle web crawler for learning platforms"
+    "description": "Moodle web crawler for learning platforms",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "jpg-newsbot",
@@ -3706,7 +4848,10 @@
       "jpg-newsbot/2.0; (+https://vipnytt.no/bots/)"
     ],
     "url": "https://vipnytt.no/bots/",
-    "description": "JPG news web crawler bot"
+    "description": "JPG news web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "outbrain",
@@ -3715,7 +4860,10 @@
       "Mozilla/5.0 (Java) outbrain"
     ],
     "url": "https://www.outbrain.com/help/advertisers/invalid-url/",
-    "description": "Outbrain web crawler for content discovery"
+    "description": "Outbrain web crawler for content discovery",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "W3C_Validator",
@@ -3724,7 +4872,10 @@
       "W3C_Validator/1.3"
     ],
     "url": "https://validator.w3.org/services",
-    "description": "W3C HTML validator web crawler bot"
+    "description": "W3C HTML validator web crawler bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Validator\\.nu",
@@ -3733,7 +4884,10 @@
       "Validator.nu/LV"
     ],
     "url": "https://validator.w3.org/services",
-    "description": "Validator.nu HTML validator web crawler"
+    "description": "Validator.nu HTML validator web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "W3C-checklink",
@@ -3753,7 +4907,10 @@
       "W3C-checklink/4.5 [4.160] libwww-perl/5.823"
     ],
     "url": "https://validator.w3.org/services",
-    "description": "W3C checklink web crawler for link validation"
+    "description": "W3C checklink web crawler for link validation",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "W3C-mobileOK",
@@ -3762,7 +4919,10 @@
       "W3C-mobileOK/DDC-1.0"
     ],
     "url": "https://validator.w3.org/services",
-    "description": "W3C mobile OK web crawler bot"
+    "description": "W3C mobile OK web crawler bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "W3C_I18n-Checker",
@@ -3771,7 +4931,10 @@
       "W3C_I18n-Checker/1.0"
     ],
     "url": "https://validator.w3.org/services",
-    "description": "W3C internationalization web crawler"
+    "description": "W3C internationalization web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "FeedValidator",
@@ -3780,7 +4943,10 @@
       "FeedValidator/1.3"
     ],
     "url": "https://validator.w3.org/services",
-    "description": "Feed validator web crawler for RSS validation"
+    "description": "Feed validator web crawler for RSS validation",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "W3C_CSS_Validator",
@@ -3789,7 +4955,10 @@
       "Jigsaw/2.3.0 W3C_CSS_Validator_JFouffa/2.0"
     ],
     "url": "https://validator.w3.org/services",
-    "description": "W3C CSS validator web crawler bot"
+    "description": "W3C CSS validator web crawler bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "W3C_Unicorn",
@@ -3798,7 +4967,10 @@
       "W3C_Unicorn/1.0"
     ],
     "url": "https://validator.w3.org/services",
-    "description": "W3C Unicorn validator web crawler bot"
+    "description": "W3C Unicorn validator web crawler bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Google-PhysicalWeb",
@@ -3806,7 +4978,10 @@
     "instances": [
       "Mozilla/5.0 (Google-PhysicalWeb)"
     ],
-    "description": "Google physical web web crawler bot"
+    "description": "Google physical web web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Blackboard",
@@ -3815,7 +4990,10 @@
       "Blackboard Safeassign"
     ],
     "url": "https://help.blackboard.com/Learn/Administrator/Hosting/Tools_Management/SafeAssign",
-    "description": "Blackboard SafeAssign web crawler bot"
+    "description": "Blackboard SafeAssign web crawler bot",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "ICBot\\/",
@@ -3824,7 +5002,10 @@
       "Mozilla/5.0 (compatible; ICBot/0.1; +https://ideasandcode.xyz"
     ],
     "url": "https://ideasandcode.xyz",
-    "description": "Ideas and Code web crawler bot"
+    "description": "Ideas and Code web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BazQux",
@@ -3833,7 +5014,10 @@
       "Mozilla/5.0 (compatible; BazQux/2.4; +https://bazqux.com/fetcher; 1 subscribers)"
     ],
     "url": "https://bazqux.com/fetcher",
-    "description": "BazQux RSS reader web crawler bot"
+    "description": "BazQux RSS reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Twingly",
@@ -3842,7 +5026,10 @@
       "Mozilla/5.0 (compatible; Twingly Recon; twingly.com)"
     ],
     "url": "https://twingly.com",
-    "description": "Twingly blog search web crawler bot"
+    "description": "Twingly blog search web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Rivva",
@@ -3851,7 +5038,10 @@
       "Mozilla/5.0 (compatible; Rivva; http://rivva.de)"
     ],
     "url": "http://rivva.de",
-    "description": "Rivva blog search web crawler bot"
+    "description": "Rivva blog search web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Experibot",
@@ -3861,7 +5051,10 @@
       "Experibot-v3 http://goo.gl/ZAr8wX"
     ],
     "url": "https://amirkr.wixsite.com/experibot",
-    "description": "Experibot web crawler for testing"
+    "description": "Experibot web crawler for testing",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "awesomecrawler",
@@ -3869,7 +5062,10 @@
     "instances": [
       "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.5 Safari/537.22 +awesomecrawler"
     ],
-    "description": "Awesome web crawler for content discovery"
+    "description": "Awesome web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Dataprovider\\.com",
@@ -3878,7 +5074,10 @@
       "Mozilla/5.0 (compatible; Dataprovider.com)"
     ],
     "url": "https://www.dataprovider.com/",
-    "description": "Dataprovider web crawler for data collection"
+    "description": "Dataprovider web crawler for data collection",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "GroupHigh\\/",
@@ -3887,7 +5086,10 @@
       "Mozilla/5.0 (compatible; GroupHigh/1.0; +http://www.grouphigh.com/"
     ],
     "url": "http://www.grouphigh.com/",
-    "description": "GroupHigh web crawler for influencer marketing"
+    "description": "GroupHigh web crawler for influencer marketing",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "theoldreader\\.com",
@@ -3896,7 +5098,10 @@
       "Mozilla/5.0 (compatible; theoldreader.com)"
     ],
     "url": "https://www.theoldreader.com/",
-    "description": "The Old Reader web crawler bot"
+    "description": "The Old Reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "AnyEvent",
@@ -3905,7 +5110,10 @@
       "Mozilla/5.0 (compatible; U; AnyEvent-HTTP/2.24; +http://software.schmorp.de/pkg/AnyEvent)"
     ],
     "url": "http://software.schmorp.de/pkg/AnyEvent.html",
-    "description": "AnyEvent Perl HTTP web crawler library"
+    "description": "AnyEvent Perl HTTP web crawler library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Uptimebot\\.org",
@@ -3914,7 +5122,10 @@
       "Uptimebot.org - Free website monitoring"
     ],
     "url": "http://uptimebot.org/",
-    "description": "Uptimebot website monitoring web crawler"
+    "description": "Uptimebot website monitoring web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Nmap Scripting Engine",
@@ -3923,7 +5134,10 @@
       "Mozilla/5.0 (compatible; Nmap Scripting Engine; https://nmap.org/book/nse.html)"
     ],
     "url": "https://nmap.org/book/nse.html",
-    "description": "Nmap NSE web crawler for security scanning"
+    "description": "Nmap NSE web crawler for security scanning",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "2ip\\.ru",
@@ -3932,7 +5146,10 @@
       "2ip.ru CMS Detector (https://2ip.ru/cms/)"
     ],
     "url": "https://2ip.ru/cms/",
-    "description": "2IP CMS detector web crawler bot"
+    "description": "2IP CMS detector web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Clickagy",
@@ -3941,7 +5158,10 @@
       "Clickagy Intelligence Bot v2"
     ],
     "url": "https://www.clickagy.com",
-    "description": "Clickagy intelligence web crawler bot"
+    "description": "Clickagy intelligence web crawler bot",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Caliperbot",
@@ -3950,7 +5170,10 @@
       "Caliperbot/1.0 (+http://www.conductor.com/caliperbot)"
     ],
     "url": "http://www.conductor.com/caliperbot",
-    "description": "Conductor Caliperbot web crawler for analysis"
+    "description": "Conductor Caliperbot web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "MBCrawler",
@@ -3959,7 +5182,10 @@
       "MBCrawler/1.0 (https://monitorbacklinks.com)"
     ],
     "url": "https://monitorbacklinks.com",
-    "description": "Monitor Backlinks web crawler bot"
+    "description": "Monitor Backlinks web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "online-webceo-bot",
@@ -3968,7 +5194,10 @@
       "Mozilla/5.0 (compatible; online-webceo-bot/1.0; +http://online.webceo.com)"
     ],
     "url": "http://online.webceo.com",
-    "description": "Online WebCEO web crawler for analysis"
+    "description": "Online WebCEO web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "B2B Bot",
@@ -3976,7 +5205,10 @@
     "instances": [
       "B2B Bot"
     ],
-    "description": "B2B web crawler for business discovery"
+    "description": "B2B web crawler for business discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AddSearchBot",
@@ -3985,7 +5217,10 @@
       "Mozilla/5.0 (compatible; AddSearchBot/0.9; +http://www.addsearch.com/bot; info@addsearch.com)"
     ],
     "url": "http://www.addsearch.com/bot",
-    "description": "AddSearch web crawler for site search"
+    "description": "AddSearch web crawler for site search",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Google Favicon",
@@ -3993,7 +5228,10 @@
     "instances": [
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36 Google Favicon"
     ],
-    "description": "Google favicon web crawler bot"
+    "description": "Google favicon web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "HubSpot",
@@ -4004,7 +5242,10 @@
       "Mozilla/5.0 (compatible; HubSpot Crawler; web-crawlers@hubspot.com)",
       "HubSpot Connect 2.0 (http://dev.hubspot.com/) - BizOpsCompanies-Tq2-BizCoDomainValidationAudit"
     ],
-    "description": "HubSpot web crawler for marketing automation"
+    "description": "HubSpot web crawler for marketing automation",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Chrome-Lighthouse",
@@ -4017,7 +5258,10 @@
       "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3694.0 Mobile Safari/537.36 Chrome-Lighthouse"
     ],
     "url": "https://developers.google.com/speed/pagespeed/insights",
-    "description": "Chrome Lighthouse web crawler for audits"
+    "description": "Chrome Lighthouse web crawler for audits",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "HeadlessChrome",
@@ -4028,7 +5272,10 @@
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/69.0.3494.0 Safari/537.36",
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/76.0.3803.0 Safari/537.36"
     ],
-    "description": "Headless Chrome web crawler for testing"
+    "description": "Headless Chrome web crawler for testing",
+    "tags": [
+      "browser-automation"
+    ]
   },
   {
     "pattern": "CheckMarkNetwork\\/",
@@ -4037,7 +5284,10 @@
       "CheckMarkNetwork/1.0 (+http://www.checkmarknetwork.com/spider.html)"
     ],
     "url": "https://www.checkmarknetwork.com/",
-    "description": "CheckMark Network web crawler bot"
+    "description": "CheckMark Network web crawler bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "www\\.uptime\\.com",
@@ -4046,7 +5296,10 @@
       "Mozilla/5.0 (compatible; Uptimebot/1.0; +http://www.uptime.com/uptimebot)"
     ],
     "url": "http://www.uptime.com/uptimebot",
-    "description": "Uptime.com website monitoring web crawler"
+    "description": "Uptime.com website monitoring web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Streamline3Bot\\/",
@@ -4056,7 +5309,10 @@
       "Mozilla/5.0 (Windows NT 6.1; Win64; x64; +https://www.ubtsupport.com/legal/Streamline3Bot.php) Streamline3Bot/1.0"
     ],
     "url": "https://www.ubtsupport.com/legal/Streamline3Bot.php",
-    "description": "Streamline3 web crawler for monitoring"
+    "description": "Streamline3 web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "serpstatbot\\/",
@@ -4066,7 +5322,10 @@
       "serpstatbot/1.0 (advanced backlink tracking bot; curl/7.58.0; http://serpstatbot.com/; abuse@serpstatbot.com)"
     ],
     "url": "http://serpstatbot.com",
-    "description": "Serpstat web crawler for backlink tracking"
+    "description": "Serpstat web crawler for backlink tracking",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "MixnodeCache\\/",
@@ -4075,7 +5334,10 @@
       "MixnodeCache/1.8(+https://cache.mixnode.com/)"
     ],
     "url": "https://cache.mixnode.com/",
-    "description": "Mixnode cache web crawler bot"
+    "description": "Mixnode cache web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "^curl",
@@ -4091,7 +5353,10 @@
       "curl/7.65.3"
     ],
     "url": "https://curl.haxx.se/",
-    "description": "cURL command-line tool for HTTP requests"
+    "description": "cURL command-line tool for HTTP requests",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "SimpleScraper",
@@ -4100,7 +5365,10 @@
       "Mozilla/5.0 (compatible; SimpleScraper)"
     ],
     "url": "https://github.com/ramonkcom/simple-scraper/",
-    "description": "Simple Scraper web scraping tool"
+    "description": "Simple Scraper web scraping tool",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "RSSingBot",
@@ -4109,7 +5377,10 @@
       "RSSingBot (http://www.rssing.com)"
     ],
     "url": "http://www.rssing.com",
-    "description": "RSSing RSS reader web crawler bot"
+    "description": "RSSing RSS reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Jooblebot",
@@ -4118,7 +5389,10 @@
       "Mozilla/5.0 (compatible; Jooblebot/2.0; Windows NT 6.1; WOW64; +http://jooble.org/jooble-bot) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36"
     ],
     "url": "http://jooble.org/jooble-bot",
-    "description": "Jooble job search web crawler bot"
+    "description": "Jooble job search web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "fedoraplanet",
@@ -4127,7 +5401,10 @@
       "venus/fedoraplanet"
     ],
     "url": "http://fedoraplanet.org/",
-    "description": "Fedora Planet web crawler for aggregation"
+    "description": "Fedora Planet web crawler for aggregation",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Friendica",
@@ -4136,7 +5413,10 @@
       "Friendica 'The Tazmans Flax-lily' 2019.01-1293; https://hoyer.xyz"
     ],
     "url": "https://hoyer.xyz",
-    "description": "Friendica social network web crawler bot"
+    "description": "Friendica social network web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "NextCloud",
@@ -4145,7 +5425,10 @@
       "NextCloud-News/1.0"
     ],
     "url": "https://nextcloud.com/",
-    "description": "NextCloud news reader web crawler bot"
+    "description": "NextCloud news reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "Tiny Tiny RSS",
@@ -4157,7 +5440,10 @@
       "Tiny Tiny RSS/19.8 (http://tt-rss.org/)"
     ],
     "url": "http://tt-rss.org/",
-    "description": "Tiny Tiny RSS reader web crawler bot"
+    "description": "Tiny Tiny RSS reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "RegionStuttgartBot",
@@ -4166,7 +5452,10 @@
       "Mozilla/5.0 (compatible; RegionStuttgartBot/1.0; +http://it.region-stuttgart.de/competenzatlas/unternehmen-suchen/)"
     ],
     "url": "http://it.region-stuttgart.de/competenzatlas/unternehmen-suchen/",
-    "description": "Region Stuttgart web crawler bot"
+    "description": "Region Stuttgart web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Bytespider",
@@ -4193,7 +5482,10 @@
       "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.9038.1080 Mobile Safari/537.36; Bytespider"
     ],
     "url": "https://stackoverflow.com/questions/57908900/what-is-the-bytespider-user-agent",
-    "description": "ByteDance Bytespider web crawler bot"
+    "description": "ByteDance Bytespider web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "Datanyze",
@@ -4202,7 +5494,10 @@
       "Mozilla/5.0 (X11; Datanyze; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36"
     ],
     "url": "https://www.datanyze.com/dnyzbot/",
-    "description": "Datanyze web crawler for technology detection"
+    "description": "Datanyze web crawler for technology detection",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Google-Site-Verification",
@@ -4211,7 +5506,10 @@
       "Mozilla/5.0 (compatible; Google-Site-Verification/1.0)"
     ],
     "url": "https://support.google.com/webmasters/answer/9008080",
-    "description": "Google site verification web crawler bot"
+    "description": "Google site verification web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "TrendsmapResolver",
@@ -4220,7 +5518,10 @@
       "Mozilla/5.0 (compatible; TrendsmapResolver/0.1)"
     ],
     "url": "https://www.trendsmap.com/",
-    "description": "Trendsmap web crawler for trend analysis"
+    "description": "Trendsmap web crawler for trend analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "tweetedtimes",
@@ -4229,7 +5530,10 @@
       "Mozilla/5.0 (compatible; +http://tweetedtimes.com)"
     ],
     "url": "https://tweetedtimes.com/",
-    "description": "Tweeted Times web crawler for news"
+    "description": "Tweeted Times web crawler for news",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "NTENTbot",
@@ -4238,7 +5542,10 @@
       "Mozilla/5.0 (compatible; NTENTbot; +http://www.ntent.com/ntentbot)"
     ],
     "url": "https://ntent.com/ntentbot/",
-    "description": "NTENT web crawler for search results"
+    "description": "NTENT web crawler for search results",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Gwene",
@@ -4247,7 +5554,10 @@
       "Gwene/1.0 (The gwene.org rss-to-news gateway) Googlebot"
     ],
     "url": "https://gwene.org",
-    "description": "Gwene RSS to news gateway web crawler"
+    "description": "Gwene RSS to news gateway web crawler",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "SimplePie",
@@ -4256,7 +5566,10 @@
       "SimplePie/1.3-dev (Feed Parser; http://simplepie.org; Allow like Gecko)"
     ],
     "url": "http://simplepie.org",
-    "description": "SimplePie PHP feed parser web crawler"
+    "description": "SimplePie PHP feed parser web crawler",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "SearchAtlas",
@@ -4265,7 +5578,10 @@
       "SearchAtlas.com SEO Crawler"
     ],
     "url": "http://SearchAtlas.com",
-    "description": "SearchAtlas SEO web crawler for analysis"
+    "description": "SearchAtlas SEO web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Superfeedr",
@@ -4274,7 +5590,10 @@
       "Superfeedr bot/2.0 http://superfeedr.com - Make your feeds realtime: get in touch - feed-id:1162088860"
     ],
     "url": "http://superfeedr.com",
-    "description": "Superfeedr feed reader web crawler bot"
+    "description": "Superfeedr feed reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "feedbot",
@@ -4283,7 +5602,10 @@
       "wp.com feedbot/1.0 (+https://wp.com)"
     ],
     "url": "http://wp.com",
-    "description": "WordPress.com feed web crawler bot"
+    "description": "WordPress.com feed web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "UT-Dorkbot",
@@ -4292,7 +5614,10 @@
       "UT-Dorkbot/1.0"
     ],
     "url": "https://security.utexas.edu/dorkbot",
-    "description": "University of Texas security web crawler"
+    "description": "University of Texas security web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Amazonbot",
@@ -4301,7 +5626,10 @@
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)"
     ],
     "url": "https://developer.amazon.com/support/amazonbot",
-    "description": "Amazon web crawler for product discovery"
+    "description": "Amazon web crawler for product discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "AmazonProductDiscovery",
@@ -4311,7 +5639,10 @@
       "Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0 (compatible; AmazonProductDiscovery/1.0; https://vendorcentral.amazon.com/support/amazonproductbot)"
     ],
     "url": "https://vendorcentral.amazon.com/support/amazonproductbot",
-    "description": "Amazon product discovery web crawler"
+    "description": "Amazon product discovery web crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "AmazonSellerInitiatedListing",
@@ -4320,7 +5651,10 @@
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 (compatible; AmazonSellerInitiatedListing/1.0; https://vendorcentral.amazon.com/support/amazonproductbot)"
     ],
     "url": "https://vendorcentral.amazon.com/support/amazonproductbot",
-    "description": "Amazon seller listing web crawler"
+    "description": "Amazon seller listing web crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "SerendeputyBot",
@@ -4329,7 +5663,10 @@
       "SerendeputyBot/0.8.6 (http://serendeputy.com/about/serendeputy-bot)"
     ],
     "url": "http://serendeputy.com/about/serendeputy-bot",
-    "description": "Serendeputy web crawler for content discovery"
+    "description": "Serendeputy web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Eyeotabot",
@@ -4338,7 +5675,10 @@
       "Mozilla/5.0 (compatible; Eyeotabot/1.0; +http://www.eyeota.com)"
     ],
     "url": "http://www.eyeota.com",
-    "description": "Eyeota web crawler for audience data"
+    "description": "Eyeota web crawler for audience data",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "officestorebot",
@@ -4347,7 +5687,10 @@
       "Mozilla/5.0 (compatible; officestorebot/1.0; +https://aka.ms/officestorebot)"
     ],
     "url": "https://aka.ms/officestorebot",
-    "description": "Microsoft Office Store web crawler bot"
+    "description": "Microsoft Office Store web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Neticle Crawler",
@@ -4356,7 +5699,10 @@
       "Neticle Crawler v1.0 ( https://neticle.com/bot/en/ )"
     ],
     "url": "https://neticle.com/bot/en/",
-    "description": "Neticle web crawler for content analysis"
+    "description": "Neticle web crawler for content analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SurdotlyBot",
@@ -4365,7 +5711,10 @@
       "Mozilla/5.0 (compatible; SurdotlyBot/1.0; +http://sur.ly/bot.html; Linux; Android 4; iPhone; CPU iPhone OS 6_0_1 like Mac OS X)"
     ],
     "url": "http://sur.ly/bot.html",
-    "description": "Surly web crawler for link shortening"
+    "description": "Surly web crawler for link shortening",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "LinkisBot",
@@ -4373,7 +5722,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; LinkisBot/1.0; bot@linkis.com) (iPhone; CPU iPhone OS 8_4_1 like Mac OS X) Mobile/12H321"
     ],
-    "description": "Linkis web crawler for link sharing"
+    "description": "Linkis web crawler for link sharing",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AwarioSmartBot",
@@ -4382,7 +5734,10 @@
       "AwarioSmartBot/1.0 (+https://awario.com/bots.html; bots@awario.com)"
     ],
     "url": "https://awario.com/bots.html",
-    "description": "Awario smart web crawler bot"
+    "description": "Awario smart web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AwarioRssBot",
@@ -4391,7 +5746,11 @@
       "AwarioRssBot/1.0 (+https://awario.com/bots.html; bots@awario.com)"
     ],
     "url": "https://awario.com/bots.html",
-    "description": "Awario RSS feed web crawler bot"
+    "description": "Awario RSS feed web crawler bot",
+    "tags": [
+      "feed-reader",
+      "seo"
+    ]
   },
   {
     "pattern": "RyteBot",
@@ -4400,7 +5759,10 @@
       "RyteBot/1.0.0 (+https://bot.ryte.com/)"
     ],
     "url": "https://bot.ryte.com/",
-    "description": "Ryte web crawler for site analysis"
+    "description": "Ryte web crawler for site analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "FreeWebMonitoring SiteChecker",
@@ -4409,7 +5771,10 @@
       "FreeWebMonitoring SiteChecker/0.2 (+https://www.freewebmonitoring.com/bot.html)"
     ],
     "url": "https://www.freewebmonitoring.com/bot.html",
-    "description": "FreeWebMonitoring site checker web crawler"
+    "description": "FreeWebMonitoring site checker web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "AspiegelBot",
@@ -4418,7 +5783,10 @@
       "Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)"
     ],
     "url": "https://aspiegel.com",
-    "description": "Aspiegel web crawler for content discovery"
+    "description": "Aspiegel web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "NAVER Blog Rssbot",
@@ -4427,7 +5795,10 @@
       "NAVER Blog Rssbot"
     ],
     "url": "http://www.naver.com",
-    "description": "Naver blog RSS web crawler bot"
+    "description": "Naver blog RSS web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "zenback bot",
@@ -4436,7 +5807,10 @@
       "Mozilla/5.0 (compatible; zenback bot; powered by logly +http://corp.logly.co.jp/)"
     ],
     "url": "http://corp.logly.co.jp/",
-    "description": "Zenback web crawler for content discovery"
+    "description": "Zenback web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SentiBot",
@@ -4445,7 +5819,10 @@
       "SentiBot www.sentibot.eu (compatible with Googlebot)"
     ],
     "url": "https://sites.google.com/senti1.com/sentibot-eu/home",
-    "description": "SentiBot web crawler for sentiment analysis"
+    "description": "SentiBot web crawler for sentiment analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Domains Project\\/",
@@ -4454,7 +5831,10 @@
       "Mozilla/5.0 (compatible; Domains Project/1.0.3; +https://github.com/tb0hdan/domains)"
     ],
     "url": "https://github.com/tb0hdan/domains",
-    "description": "Domains Project web crawler bot"
+    "description": "Domains Project web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Pandalytics",
@@ -4463,7 +5843,10 @@
       "Pandalytics/1.0 (https://domainsbot.com/pandalytics/)"
     ],
     "url": "https://domainsbot.com/pandalytics/",
-    "description": "Pandalytics web crawler for domain analysis"
+    "description": "Pandalytics web crawler for domain analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "VKRobot",
@@ -4471,7 +5854,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; VKRobot/1.0)"
     ],
-    "description": "VK social network web crawler bot"
+    "description": "VK social network web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "bidswitchbot",
@@ -4480,7 +5866,10 @@
       "bidswitchbot/1.0"
     ],
     "url": "https://www.bidswitch.com/about-us/",
-    "description": "BidSwitch web crawler for advertising"
+    "description": "BidSwitch web crawler for advertising",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "tigerbot",
@@ -4488,7 +5877,10 @@
     "instances": [
       "tigerbot"
     ],
-    "description": "Tiger web crawler for content discovery"
+    "description": "Tiger web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "NIXStatsbot",
@@ -4497,7 +5889,10 @@
       "Mozilla/5.0 (compatible; NIXStatsbot/1.1; +http://www.nixstats.com/bot.html)"
     ],
     "url": "http://www.nixstats.com/bot.html",
-    "description": "NIXStats web crawler for monitoring"
+    "description": "NIXStats web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Atom Feed Robot",
@@ -4506,7 +5901,10 @@
       "RSSMicro.com RSS/Atom Feed Robot"
     ],
     "url": "https://rssmicro.com",
-    "description": "RSSMicro atom feed web crawler bot"
+    "description": "RSSMicro atom feed web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "[Cc]urebot",
@@ -4515,7 +5913,10 @@
       "Curebot/1.0",
       "curebot-feed-fetcher"
     ],
-    "description": "Cure web crawler for content discovery"
+    "description": "Cure web crawler for content discovery",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "PagePeeker\\/",
@@ -4524,7 +5925,10 @@
       "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 (compatible; PagePeeker/3.0; +https://pagepeeker.com/robots/)"
     ],
     "url": "https://pagepeeker.com/robots/",
-    "description": "PagePeeker web crawler for screenshots"
+    "description": "PagePeeker web crawler for screenshots",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Vigil\\/",
@@ -4533,7 +5937,10 @@
       "Mozilla/5.0 (compatible; Vigil/1.0; +http://vigil-app.com/bot.html)"
     ],
     "url": "http://vigil-app.com/bot.html",
-    "description": "Vigil web crawler for monitoring"
+    "description": "Vigil web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "rssbot\\/",
@@ -4542,7 +5949,10 @@
       "rssbot/1.4.3 (+https://t.me/RustRssBot)"
     ],
     "url": "https://github.com/iovxw/rssbot",
-    "description": "RSS bot web crawler for feeds"
+    "description": "RSS bot web crawler for feeds",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "startmebot\\/",
@@ -4551,7 +5961,10 @@
       "Mozilla/5.0 (compatible; startmebot/1.0; +https://start.me/bot)"
     ],
     "url": "https://start.me/bot",
-    "description": "Start.me web crawler for content discovery"
+    "description": "Start.me web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "JobboerseBot",
@@ -4560,7 +5973,10 @@
       "Mozilla/5.0 (X11; U; Linux Core i7-4980HQ; de; rv:32.0; compatible; JobboerseBot; http://www.jobboerse.com/bot.htm) Gecko/20100101 Firefox/38.0"
     ],
     "url": "http://www.jobboerse.com/bot.htm",
-    "description": "Jobboerse web crawler for job discovery"
+    "description": "Jobboerse web crawler for job discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "seewithkids",
@@ -4569,7 +5985,10 @@
       "http://seewithkids.com/bot"
     ],
     "url": "http://seewithkids.com/bot",
-    "description": "SeeWithKids web crawler for content discovery"
+    "description": "SeeWithKids web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "NINJA bot",
@@ -4577,7 +5996,10 @@
     "instances": [
       "NINJA bot"
     ],
-    "description": "NINJA web crawler for content discovery"
+    "description": "NINJA web crawler for content discovery",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Cutbot",
@@ -4586,7 +6008,10 @@
       "Cutbot; 1.5; http://cutbot.net/"
     ],
     "url": "http://cutbot.net/",
-    "description": "Cutbot web crawler for content discovery"
+    "description": "Cutbot web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BublupBot",
@@ -4595,7 +6020,10 @@
       "BublupBot (+https://www.bublup.com/bublup-bot.html)"
     ],
     "url": "https://www.bublup.com/bublup-bot.html",
-    "description": "Bublup web crawler for content discovery"
+    "description": "Bublup web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BrandONbot",
@@ -4604,7 +6032,10 @@
       "BrandONbot (http://brandonmedia.net)"
     ],
     "url": "http://brandonmedia.net",
-    "description": "BrandON web crawler for brand monitoring"
+    "description": "BrandON web crawler for brand monitoring",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "RidderBot",
@@ -4614,7 +6045,10 @@
       "Mozilla/5.0 (compatible; RidderBot/1.0; bot@ridder.co) (iPhone; CPU iPhone OS 8_4_1 like Mac OS X) Mobile/12H321"
     ],
     "url": "https://ridder.co/",
-    "description": "Ridder web crawler for content discovery"
+    "description": "Ridder web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Taboolabot",
@@ -4623,7 +6057,10 @@
       "Mozilla/5.0 (compatible; Taboolabot/3.7; +http://www.taboola.com)"
     ],
     "url": "http://www.taboola.com",
-    "description": "Taboola web crawler for content discovery"
+    "description": "Taboola web crawler for content discovery",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Dubbotbot",
@@ -4632,7 +6069,10 @@
       "Mozilla/5.0 (compatible; Dubbotbot/0.2; +http://dubbot.com)"
     ],
     "url": "http://dubbot.com",
-    "description": "Dubbot web crawler for content discovery"
+    "description": "Dubbot web crawler for content discovery",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "FindITAnswersbot",
@@ -4641,7 +6081,10 @@
       "Mozilla/5.0 (compatible;FindITAnswersbot/1.0;+http://search.it-influentials.com/bot.htm)"
     ],
     "url": "http://search.it-influentials.com/bot.htm",
-    "description": "FindITAnswers web crawler for discovery"
+    "description": "FindITAnswers web crawler for discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "infoobot",
@@ -4650,7 +6093,10 @@
       "infoobot/0.1 (https://www.infoo.nl/bot.html)"
     ],
     "url": "https://www.infoo.nl/bot.html",
-    "description": "Infoo web crawler for content discovery"
+    "description": "Infoo web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Refindbot",
@@ -4659,7 +6105,10 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 (Refindbot/1.0)"
     ],
     "url": "https://refind.com/about",
-    "description": "Refind web crawler for content discovery"
+    "description": "Refind web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BlogTraffic\\/\\d\\.\\d+ Feed-Fetcher",
@@ -4668,7 +6117,10 @@
       "Mozilla/5.0 (compatible; BlogTraffic/1.4 Feed-Fetcher; +http://www.blogtraffic.de/rss-bot.html)"
     ],
     "url": "http://www.blogtraffic.de/rss-bot.html",
-    "description": "BlogTraffic feed fetcher web crawler"
+    "description": "BlogTraffic feed fetcher web crawler",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "SeobilityBot",
@@ -4677,7 +6129,10 @@
       "SeobilityBot (SEO Tool; https://www.seobility.net/sites/bot.html)"
     ],
     "url": "https://www.seobility.net/sites/bot.html",
-    "description": "Seobility web crawler for SEO analysis"
+    "description": "Seobility web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Cincraw",
@@ -4686,7 +6141,10 @@
       "Mozilla/5.0 (compatible; Cincraw/1.0; +http://cincrawdata.net/bot/)"
     ],
     "url": "http://cincrawdata.net/bot/",
-    "description": "Cincraw web crawler for data collection"
+    "description": "Cincraw web crawler for data collection",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Dragonbot",
@@ -4695,7 +6153,10 @@
       "Mozilla/5.0 (Windows NT 6.1; rv:34.0) Gecko/20100101 Firefox/34.0; Dragonbot; http://www.dragonmetrics.com"
     ],
     "url": "http://www.dragonmetrics.com",
-    "description": "DragonMetrics web crawler for analysis"
+    "description": "DragonMetrics web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "VoluumDSP-content-bot",
@@ -4704,7 +6165,10 @@
       "Mozilla/5.0 (compatible; VoluumDSP-content-bot/2.0; +dsp-dev@codewise.com)"
     ],
     "url": "https://codewise.com",
-    "description": "Voluum DSP web crawler for advertising"
+    "description": "Voluum DSP web crawler for advertising",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "FreshRSS",
@@ -4713,7 +6177,10 @@
       "FreshRSS/1.11.2 (Linux; https://freshrss.org) like Googlebot"
     ],
     "url": "https://freshrss.org",
-    "description": "FreshRSS feed reader web crawler bot"
+    "description": "FreshRSS feed reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "BitBot",
@@ -4722,7 +6189,10 @@
       "Mozilla/5.0 (compatible; BitBot/v1.19.0; +https://bitbot.dev)"
     ],
     "url": "https://bitbot.dev",
-    "description": "BitBot web crawler for content discovery"
+    "description": "BitBot web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "^PHP-Curl-Class",
@@ -4737,7 +6207,10 @@
       "PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.4.11 curl/7.69.1"
     ],
     "url": "https://github.com/php-curl-class/php-curl-class",
-    "description": "PHP Curl Class HTTP client library"
+    "description": "PHP Curl Class HTTP client library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Google-Certificates-Bridge",
@@ -4745,7 +6218,10 @@
     "instances": [
       "Google-Certificates-Bridge"
     ],
-    "description": "Google certificates bridge web crawler"
+    "description": "Google certificates bridge web crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "centurybot",
@@ -4753,7 +6229,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Go-http-client/1.1; +centurybot9@gmail.com)"
     ],
-    "description": "Century web crawler for content discovery"
+    "description": "Century web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Viber",
@@ -4762,7 +6241,10 @@
       "Viber"
     ],
     "url": "https://www.viber.com/",
-    "description": "Viber messaging web crawler bot"
+    "description": "Viber messaging web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "e\\.ventures Investment Crawler",
@@ -4771,7 +6253,10 @@
     "instances": [
       "e.ventures Investment Crawler (eventures.vc)"
     ],
-    "description": "E.ventures investment web crawler bot"
+    "description": "E.ventures investment web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "evc-batch",
@@ -4780,7 +6265,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; evc-batch/2.0)"
     ],
-    "description": "E.ventures batch web crawler bot"
+    "description": "E.ventures batch web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "PetalBot",
@@ -4790,7 +6278,10 @@
       "Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; PetalBot;+https://webmaster.petalsearch.com/site/petalbot)"
     ],
     "url": "https://webmaster.petalsearch.com/site/petalbot",
-    "description": "Petal search engine web crawler bot"
+    "description": "Petal search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "virustotal",
@@ -4800,7 +6291,10 @@
       "AppEngine-Google; (+http://code.google.com/appengine; appid: s~virustotalcloud)"
     ],
     "url": "https://www.virustotal.com/gui/home/url",
-    "description": "VirusTotal web crawler for security"
+    "description": "VirusTotal web crawler for security",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "(^| )PTST\\/",
@@ -4810,7 +6304,10 @@
       "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0 PTST/211202.211915"
     ],
     "url": "https://www.webpagetest.org",
-    "description": "WebPageTest web crawler for testing"
+    "description": "WebPageTest web crawler for testing",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "minicrawler",
@@ -4819,7 +6316,10 @@
       "Testomatobot/1.0 (Linux x86_64; +https://www.testomato.com/testomatobot) minicrawler/5.2.2"
     ],
     "url": "https://www.testomato.com/bot",
-    "description": "Testomato web crawler for testing"
+    "description": "Testomato web crawler for testing",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Cookiebot",
@@ -4828,7 +6328,10 @@
     "instances": [
       "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; Cookiebot/1.0; +http://cookiebot.com/) Chrome/97.0.4692.71 Safari/537.36"
     ],
-    "description": "Cookiebot web crawler for cookie scanning"
+    "description": "Cookiebot web crawler for cookie scanning",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "trovitBot",
@@ -4837,7 +6340,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; trovitBot 1.0; +http://www.trovit.com/bot.html)"
     ],
-    "description": "Trovit web crawler for content discovery"
+    "description": "Trovit web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "seostar\\.co",
@@ -4846,7 +6352,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Adsbot/3.1; +https://seostar.co/robot/)"
     ],
-    "description": "SEOstar web crawler for SEO analysis"
+    "description": "SEOstar web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "IonCrawl",
@@ -4855,7 +6364,10 @@
     "instances": [
       "IonCrawl (https://www.ionos.de/terms-gtc/faq-crawler-en/)"
     ],
-    "description": "IONOS IonCrawl web crawler bot"
+    "description": "IONOS IonCrawl web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Uptime-Kuma",
@@ -4871,7 +6383,10 @@
       "Uptime-Kuma/1.23.10",
       "Uptime-Kuma/1.18.0"
     ],
-    "description": "Uptime Kuma web crawler for monitoring"
+    "description": "Uptime Kuma web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Seekport",
@@ -4881,7 +6396,10 @@
       "Mozilla/5.0 (compatible; SeekportBot; +https://bot.seekport.com)",
       "Mozilla/5.0 (compatible; Seekport Crawler; http://seekport.com/)"
     ],
-    "description": "Seekport web crawler for content discovery"
+    "description": "Seekport web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "FreshpingBot",
@@ -4890,7 +6408,10 @@
     "instances": [
       "FreshpingBot/1.0 (+https://freshping.io/)"
     ],
-    "description": "Freshping web crawler for monitoring"
+    "description": "Freshping web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Feedbin",
@@ -4899,7 +6420,10 @@
     "instances": [
       "Feedbin feed-id:2005098 - 2 subscribers"
     ],
-    "description": "Feedbin feed reader web crawler bot"
+    "description": "Feedbin feed reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "CriteoBot",
@@ -4908,7 +6432,10 @@
     "instances": [
       "CriteoBot/0.1 (+https://www.criteo.com/criteo-crawler/)"
     ],
-    "description": "Criteo web crawler for advertising"
+    "description": "Criteo web crawler for advertising",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "Snap URL Preview Service",
@@ -4917,7 +6444,10 @@
     "instances": [
       "Snap URL Preview Service; bot; snapchat; https://developers.snap.com/robots"
     ],
-    "description": "Snapchat URL preview web crawler"
+    "description": "Snapchat URL preview web crawler",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Better Uptime Bot",
@@ -4926,7 +6456,10 @@
     "instances": [
       "Better Uptime Bot Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     ],
-    "description": "Better Uptime web crawler for monitoring"
+    "description": "Better Uptime web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "RuxitSynthetic",
@@ -4935,7 +6468,10 @@
     "instances": [
       "RuxitSynthetic/1.0"
     ],
-    "description": "Dynatrace Ruxit synthetic web crawler"
+    "description": "Dynatrace Ruxit synthetic web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Google-Read-Aloud",
@@ -4945,7 +6481,10 @@
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36 (compatible; Google-Read-Aloud; +https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers)",
       "Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36 (compatible; Google-Read-Aloud; +https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers)"
     ],
-    "description": "Google read aloud web crawler bot"
+    "description": "Google read aloud web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Valve\\/Steam",
@@ -4953,7 +6492,10 @@
     "instances": [
       "Valve/Steam HTTP Client 1.0 (SteamChatURLLookup)"
     ],
-    "description": "Steam web crawler for link previews"
+    "description": "Steam web crawler for link previews",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "OdklBot\\/",
@@ -4963,7 +6505,10 @@
       "Mozilla/5.0 (compatible; OdklBot/1.0 like Linux; klass@odnoklassniki.ru)"
     ],
     "url": "https://odnoklassniki.ru/",
-    "description": "Odnoklassniki web crawler for sharing"
+    "description": "Odnoklassniki web crawler for sharing",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "GPTBot",
@@ -4972,7 +6517,10 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.0; +https://openai.com/gptbot)"
     ],
     "url": "https://platform.openai.com/docs/gptbot",
-    "description": "OpenAI GPT web crawler bot"
+    "description": "OpenAI GPT web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "ChatGPT-User",
@@ -4981,7 +6529,10 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot"
     ],
     "url": "https://openai.com/bot",
-    "description": "ChatGPT user web crawler bot"
+    "description": "ChatGPT user web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "OAI-SearchBot",
@@ -4990,7 +6541,11 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot"
     ],
     "url": "https://platform.openai.com/docs/bots",
-    "description": "OpenAI search web crawler bot"
+    "description": "OpenAI search web crawler bot",
+    "tags": [
+      "ai-crawler",
+      "search-engine"
+    ]
   },
   {
     "pattern": "YandexRenderResourcesBot\\/",
@@ -4999,7 +6554,10 @@
       "Mozilla/5.0 (compatible; YandexRenderResourcesBot/1.0; +http://yandex.com/bots) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0"
     ],
     "url": "http://yandex.com/bots",
-    "description": "Yandex render resources web crawler"
+    "description": "Yandex render resources web crawler",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "LightspeedSystemsCrawler",
@@ -5007,7 +6565,10 @@
     "instances": [
       "LightspeedSystemsCrawler Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US"
     ],
-    "description": "Lightspeed Systems web crawler bot"
+    "description": "Lightspeed Systems web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "ev-crawler\\/",
@@ -5016,7 +6577,10 @@
       "Mozilla/5.0 (compatible; ev-crawler/1.0; +https://headline.com/legal/crawler)"
     ],
     "url": "https://headline.com/legal/crawler",
-    "description": "Headline web crawler for content discovery"
+    "description": "Headline web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "BitSightBot\\/",
@@ -5025,7 +6589,10 @@
       "Mozilla/5.0 (compatible; BitSightBot/1.0)"
     ],
     "url": "https://www.bitsight.com",
-    "description": "BitSight web crawler for security"
+    "description": "BitSight web crawler for security",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "woorankreview\\/",
@@ -5035,7 +6602,10 @@
       "Mozilla/5.0 (compatible; woorankreview/2.0; +https://www.woorank.com/)"
     ],
     "url": "https://www.woorank.com/",
-    "description": "WooRank web crawler for SEO analysis"
+    "description": "WooRank web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Google-Safety",
@@ -5046,7 +6616,10 @@
       "Google-Safety"
     ],
     "url": "https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers",
-    "description": "Google safety web crawler bot"
+    "description": "Google safety web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "AwarioBot",
@@ -5055,7 +6628,10 @@
       "Mozilla/5.0 (compatible; AwarioBot/1.0; +https://awario.com/bots.html)"
     ],
     "url": "https://awario.com/bots.html",
-    "description": "Awario web crawler for monitoring"
+    "description": "Awario web crawler for monitoring",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "DataForSeoBot",
@@ -5064,7 +6640,10 @@
       "Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)"
     ],
     "url": "https://dataforseo.com/dataforseo-bot",
-    "description": "DataForSEO web crawler for analysis"
+    "description": "DataForSEO web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Linespider",
@@ -5074,7 +6653,10 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Linespider/1.1; +https://lin.ee/4dwXkTH) Chrome/W.X.Y.Z Safari/537.36"
     ],
     "url": "https://help2.line.me/linesearchbot/web/?contentId=50006055&lang=en",
-    "description": "LINE Linespider web crawler bot"
+    "description": "LINE Linespider web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "WellKnownBot",
@@ -5083,7 +6665,10 @@
       "Mozilla/5.0 (compatible; WellKnownBot/0.1; +https://well-known.dev/about/#bot)"
     ],
     "url": "https://well-known.dev/about/#bot)",
-    "description": "WellKnown web crawler for discovery"
+    "description": "WellKnown web crawler for discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "A Patent Crawler",
@@ -5092,7 +6677,10 @@
       "E. Orliac, G. Fourestey/2.3 (A Patent Crawler; http://scitas.epfl.ch/; etienne.orliac@epfl.ch, gilles.fourestey@epfl.ch)"
     ],
     "url": "http://scitas.epfl.ch/",
-    "description": "EPFL patent web crawler bot"
+    "description": "EPFL patent web crawler bot",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "StractBot",
@@ -5101,7 +6689,10 @@
       "Mozilla/5.0 (compatible; StractBot/0.1; open source search engine; +https://trystract.com/webmasters)"
     ],
     "url": "https://trystract.com/webmasters",
-    "description": "Stract search engine web crawler bot"
+    "description": "Stract search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "search\\.marginalia\\.nu",
@@ -5110,7 +6701,10 @@
       "search.marginalia.nu"
     ],
     "url": "https://search.marginalia.nu",
-    "description": "Marginalia search web crawler bot"
+    "description": "Marginalia search web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "YouBot",
@@ -5119,7 +6713,10 @@
       "YouBot (+http://www.you.com)"
     ],
     "url": "https://you.com/",
-    "description": "You.com search engine web crawler bot"
+    "description": "You.com search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Nicecrawler",
@@ -5128,7 +6725,10 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Nicecrawler/1.1; +http://www.nicecrawler.com/) Chrome/90.0.4430.97 Safari/537.36"
     ],
     "url": "http://www.nicecrawler.com/",
-    "description": "Nicecrawler web crawler for discovery"
+    "description": "Nicecrawler web crawler for discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Neevabot",
@@ -5137,7 +6737,10 @@
       "Mozilla/5.0 (compatible; Neevabot/1.0; +https://neeva.com/neevabot)"
     ],
     "url": "https://neeva.com/neevabot",
-    "description": "Neeva search engine web crawler bot"
+    "description": "Neeva search engine web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "BrightEdge Crawler",
@@ -5146,7 +6749,10 @@
       "BrightEdge Crawler/1.0 (crawler@brightedge.com)"
     ],
     "url": "https://www.brightedge.com/",
-    "description": "BrightEdge web crawler for SEO"
+    "description": "BrightEdge web crawler for SEO",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SiteCheckerBotCrawler",
@@ -5155,7 +6761,10 @@
       "SiteCheckerBotCrawler/1.0 (+http://sitechecker.pro)"
     ],
     "url": "http://sitechecker.pro",
-    "description": "SiteChecker web crawler for analysis"
+    "description": "SiteChecker web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "TombaPublicWebCrawler",
@@ -5164,7 +6773,10 @@
       "Mozilla/5.0 (compatible; TombaPublicWebCrawler/1.0; +https://tombascraper.com)"
     ],
     "url": "https://tombascraper.com",
-    "description": "Tomba web crawler for email discovery"
+    "description": "Tomba web crawler for email discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "CrawlyProjectCrawler",
@@ -5173,7 +6785,10 @@
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 (compatible; CrawlyProjectCrawler/0.1.3; crawlyproject@digitaldragon.dev +https://crawlyproject.digitaldragon.dev/)"
     ],
     "url": "https://crawlyproject.digitaldragon.dev/",
-    "description": "Crawly Project web crawler framework"
+    "description": "Crawly Project web crawler framework",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "KomodiaBot",
@@ -5182,7 +6797,10 @@
       "Mozilla/5.0 (Windows NT 6.1; Win64; x64; +http://www.komodia.com/newwiki/index.php/URL_server_crawler) KomodiaBot/1.0"
     ],
     "url": "http://www.komodia.com/newwiki/index.php/URL_server_crawler",
-    "description": "Komodia web crawler for classification"
+    "description": "Komodia web crawler for classification",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "KStandBot",
@@ -5191,7 +6809,10 @@
       "Mozilla/5.0 (Windows NT 6.1; Win64; x64; +http://url-classification.io/wiki/index.php?title=URL_server_crawler) KStandBot/1.0"
     ],
     "url": "http://url-classification.io",
-    "description": "KStand web crawler for classification"
+    "description": "KStand web crawler for classification",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "CISPA Webcrawler",
@@ -5200,7 +6821,10 @@
       "CISPA Webcrawler (https://vuln-notify-checker.cispa.saarland)"
     ],
     "url": "https://vuln-notify-checker.cispa.saarland",
-    "description": "CISPA web crawler for vulnerability"
+    "description": "CISPA web crawler for vulnerability",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "MTRobot",
@@ -5209,7 +6833,10 @@
       "MTRobot/0.2 (Metrics Tools Analytics Crawler; https://metrics-tools.de/robot.html; crawler@metrics-tools.de)"
     ],
     "url": "https://metrics-tools.de/robot.html",
-    "description": "Metrics Tools web crawler for analysis"
+    "description": "Metrics Tools web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "hyscore\\.io",
@@ -5218,7 +6845,10 @@
       "Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1. 4 (compatible; HyScore/1.0; +https://hyscore.io/crawler/)"
     ],
     "url": "https://hyscore.io/crawler/",
-    "description": "HyScore web crawler for analysis"
+    "description": "HyScore web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "AlexandriaOrgBot",
@@ -5227,7 +6857,10 @@
       "Mozilla/5.0 (Linux) (compatible; AlexandriaOrgBot/1.0; +https://www.alexandria.org/bot.html)"
     ],
     "url": "https://www.alexandria.org/bot.html",
-    "description": "Alexandria web crawler for discovery"
+    "description": "Alexandria web crawler for discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "2ip bot",
@@ -5236,7 +6869,10 @@
       "2ip bot/1.1 (+http://2ip.io)"
     ],
     "url": "http://2ip.io",
-    "description": "2IP web crawler for analysis"
+    "description": "2IP web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Yellowbrandprotectionbot",
@@ -5245,7 +6881,10 @@
       "Mozilla/5.0 (compatible; Yellowbrandprotectionbot/1.0; +https://www.yellowbp.com/bot.html)"
     ],
     "url": "https://www.yellowbp.com/bot.html",
-    "description": "Yellow brand protection web crawler"
+    "description": "Yellow brand protection web crawler",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "SEOlizer",
@@ -5254,7 +6893,10 @@
       "SEOlizer/1.1 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13 (+https://www.seolizer.de/bot.html)"
     ],
     "url": "https://www.seolizer.de/bot.html",
-    "description": "SEOlizer web crawler for SEO analysis"
+    "description": "SEOlizer web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "vuhuvBot",
@@ -5263,7 +6905,10 @@
       "Mozilla/5.0 (compatible; vuhuvBot/1.0; +http://vuhuv.com/bot.html)"
     ],
     "url": "http://vuhuv.com/bot.html",
-    "description": "Vuhuv web crawler for content discovery"
+    "description": "Vuhuv web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "INETDEX-BOT",
@@ -5272,7 +6917,10 @@
       "INETDEX-BOT/1.5 (Mozilla/5.0; https://inetdex.com/bot.html)"
     ],
     "url": "https://inetdex.com/bot.html",
-    "description": "INETDEX web crawler for indexing"
+    "description": "INETDEX web crawler for indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Synapse",
@@ -5281,7 +6929,10 @@
       "Synapse (bot; +https://github.com/matrix-org/synapse)"
     ],
     "url": "https://github.com/matrix-org/synapse",
-    "description": "Matrix Synapse web crawler bot"
+    "description": "Matrix Synapse web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "t3versionsBot",
@@ -5290,7 +6941,10 @@
       "Mozilla/5.0 (compatible; t3versionsBot/1.0; +https://www.t3versions.com/bot)"
     ],
     "url": "https://www.t3versions.com/bot",
-    "description": "T3versions web crawler for discovery"
+    "description": "T3versions web crawler for discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "deepnoc",
@@ -5299,7 +6953,10 @@
       "deepnoc - https://deepnoc.com/bot"
     ],
     "url": "https://deepnoc.com/bot",
-    "description": "DeepNOC web crawler for monitoring"
+    "description": "DeepNOC web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Cocolyzebot",
@@ -5308,7 +6965,10 @@
       "Mozilla/5.0 (compatible; Cocolyzebot/1.0; https://cocolyze.com/bot)"
     ],
     "url": "https://cocolyze.com/bot",
-    "description": "Cocolyze web crawler for analysis"
+    "description": "Cocolyze web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "hypestat",
@@ -5317,7 +6977,10 @@
       "Mozilla/5.0 (compatible; hypestat/1.0; +https://hypestat.com/bot)"
     ],
     "url": "https://hypestat.com/bot",
-    "description": "Hypestat web crawler for analysis"
+    "description": "Hypestat web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "ReverseEngineeringBot",
@@ -5326,7 +6989,10 @@
       "Mozilla/5.0 (compatible; ReverseEngineeringBot/0.1; +https://torus.company/bot.html)"
     ],
     "url": "https://torus.company/bot.html",
-    "description": "Torus reverse engineering web crawler"
+    "description": "Torus reverse engineering web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "sempi\\.tech",
@@ -5335,7 +7001,10 @@
       "Mozilla/5.0 (compatible; Semanticbot/1.0; +http://sempi.tech/bot.html)"
     ],
     "url": "http://sempi.tech/bot.html",
-    "description": "Sempi web crawler for analysis"
+    "description": "Sempi web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Iframely",
@@ -5344,7 +7013,10 @@
       "Iframely/1.3.1 (+https://iframely.com/docs/about) Atlassian"
     ],
     "url": "https://iframely.com/docs/about",
-    "description": "Iframely web crawler for embeds"
+    "description": "Iframely web crawler for embeds",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "MetaInspector",
@@ -5353,7 +7025,10 @@
       "MetaInspector/5.6.0 (+https://github.com/jaimeiniesta/metainspector)"
     ],
     "url": "https://github.com/jaimeiniesta/metainspector",
-    "description": "MetaInspector web crawler for metadata"
+    "description": "MetaInspector web crawler for metadata",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "node-fetch",
@@ -5362,7 +7037,10 @@
       "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
     ],
     "url": "https://github.com/bitinn/node-fetch",
-    "description": "Node-fetch HTTP client library"
+    "description": "Node-fetch HTTP client library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "l9explore",
@@ -5372,7 +7050,10 @@
       "lkxscan/v0.1.0 (+https://leakix.net) l9explore/v1.0.0 (+https://github.com/LeakIX/l9explore)"
     ],
     "url": "https://github.com/LeakIX/l9explore",
-    "description": "L9explore web crawler for discovery"
+    "description": "L9explore web crawler for discovery",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "python-opengraph",
@@ -5381,7 +7062,10 @@
       "python-opengraph-jaywink/0.2.0 (+https://github.com/jaywink/python-opengraph)"
     ],
     "url": "https://github.com/jaywink/python-opengraph",
-    "description": "Python OpenGraph web crawler bot"
+    "description": "Python OpenGraph web crawler bot",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "OpenGraphCheck",
@@ -5390,7 +7074,10 @@
       "OpenGraphCheck/2.1 (+https://opengraphcheck.com)"
     ],
     "url": "https://opengraphcheck.com",
-    "description": "OpenGraphCheck web crawler for metadata"
+    "description": "OpenGraphCheck web crawler for metadata",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "developers\\.google\\.com\\/\\+\\/web\\/snippet",
@@ -5400,7 +7087,10 @@
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 Google (+https://developers.google.com/+/web/snippet/"
     ],
     "url": "https://developers.google.com/+/web/snippet",
-    "description": "Google snippet web crawler bot"
+    "description": "Google snippet web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "SenutoBot",
@@ -5409,7 +7099,10 @@
       "SenutoBot/1.0 (compatible; SenutoBot/1.0; +https://www.senuto.com/)"
     ],
     "url": "https://www.senuto.com",
-    "description": "Senuto web crawler for SEO analysis"
+    "description": "Senuto web crawler for SEO analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "MaCoCu",
@@ -5418,7 +7111,10 @@
       "Mozilla/5.0 (compatible; MaCoCu; +https://www.clarin.si/info/macocu-massive-collection-and-curation-of-monolingual-and-bilingual-data/)"
     ],
     "url": "https://www.clarin.si/info/macocu-massive-collection-and-curation-of-monolingual-and-bilingual-data",
-    "description": "MaCoCu web crawler for language research"
+    "description": "MaCoCu web crawler for language research",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "NewsBlur",
@@ -5427,7 +7123,10 @@
       "NewsBlur Feed Fetcher - 1 subscriber - http://www.newsblur.com/site/0000000/webpage (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Safari/605.1.15)"
     ],
     "url": "http://www.newsblur.com",
-    "description": "NewsBlur feed reader web crawler bot"
+    "description": "NewsBlur feed reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "inoreader",
@@ -5436,7 +7135,10 @@
       "Mozilla/5.0 (compatible; inoreader.com; 1 subscribers)"
     ],
     "url": "http://inoreader.com",
-    "description": "Inoreader feed reader web crawler bot"
+    "description": "Inoreader feed reader web crawler bot",
+    "tags": [
+      "feed-reader"
+    ]
   },
   {
     "pattern": "NetSystemsResearch",
@@ -5445,7 +7147,10 @@
       "NetSystemsResearch studies the availability of various services across the internet. Our website is netsystemsresearch.com"
     ],
     "url": "http://netsystemsresearch.com",
-    "description": "NetSystemsResearch web crawler bot"
+    "description": "NetSystemsResearch web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "PageThing",
@@ -5454,7 +7159,10 @@
       "PageThing http://pagething.com curl www"
     ],
     "url": "http://pagething.com",
-    "description": "PageThing web crawler for content discovery"
+    "description": "PageThing web crawler for content discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "WordPress\\/",
@@ -5463,7 +7171,10 @@
       "WordPress/X.X.X; https://example.com"
     ],
     "url": "https://wordpress.org",
-    "description": "WordPress web crawler for site discovery"
+    "description": "WordPress web crawler for site discovery",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "PhxBot",
@@ -5471,7 +7182,10 @@
     "instances": [
       "PhxBot/0.1 (phxbot@protonmail.com)"
     ],
-    "description": "Phoenix web crawler for content discovery"
+    "description": "Phoenix web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "ImagesiftBot",
@@ -5480,7 +7194,10 @@
       "Mozilla/5.0 (compatible; ImagesiftBot; +imagesift.com)"
     ],
     "url": "https://imagesift.com/about",
-    "description": "Imagesift bot for image search and indexing"
+    "description": "Imagesift bot for image search and indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Expanse",
@@ -5489,7 +7206,10 @@
       "Expanse, a Palo Alto Networks company, searches across the global IPv4 space multiple times per day to identify customers&#39; presences on the Internet. If you would like to be excluded from our scans, please send IP addresses/domains to: scaninfo@paloaltonetworks.com"
     ],
     "url": "https://www.paloaltonetworks.com/cortex/cortex-xpanse",
-    "description": "Palo Alto Networks Expanse bot for internet asset discovery"
+    "description": "Palo Alto Networks Expanse bot for internet asset discovery",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "InternetMeasurement",
@@ -5498,7 +7218,10 @@
       "Mozilla/5.0 (compatible; InternetMeasurement/1.0; +https://internet-measurement.com/)"
     ],
     "url": "https://internet-measurement.com",
-    "description": "Internet Measurement bot for network research and analysis"
+    "description": "Internet Measurement bot for network research and analysis",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "^BW\\/",
@@ -5508,7 +7231,10 @@
       "BW/1.1; rb.gy/oupwis"
     ],
     "url": "https://builtwith.com/biup",
-    "description": "BuiltWith web crawler for technology detection"
+    "description": "BuiltWith web crawler for technology detection",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "GeedoBot",
@@ -5517,7 +7243,10 @@
       "Mozilla/5.0 (compatible; GeedoBot; +http://www.geedo.com/bot.html)"
     ],
     "url": "http://www.geedo.com",
-    "description": "Geedo web crawler for content discovery"
+    "description": "Geedo web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "Audisto Crawler",
@@ -5529,7 +7258,10 @@
       "Audisto Crawler (desktop; essential; +https://audisto.com/bot)"
     ],
     "url": "https://audisto.com/help/crawler/bot/",
-    "description": "Audisto SEO web crawler for analysis"
+    "description": "Audisto SEO web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "PerplexityBot\\/",
@@ -5538,7 +7270,11 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)"
     ],
     "url": "https://docs.perplexity.ai/docs/perplexitybot",
-    "description": "Perplexity AI web crawler for search"
+    "description": "Perplexity AI web crawler for search",
+    "tags": [
+      "ai-crawler",
+      "search-engine"
+    ]
   },
   {
     "pattern": "[cC]laude[bB]ot",
@@ -5548,7 +7284,10 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ClaudeBot/1.0; +claudebot@anthropic.com)"
     ],
     "url": "https://www.anthropic.com/",
-    "description": "Anthropic Claude web crawler bot"
+    "description": "Anthropic Claude web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "Monsidobot",
@@ -5557,7 +7296,10 @@
       "Mozilla/5.0 (compatible; Monsidobot/2.2; +http://monsido.com/bot.html; info@monsido.com)"
     ],
     "url": "http://monsido.com/bot.html",
-    "description": "Monsido web crawler for website monitoring"
+    "description": "Monsido web crawler for website monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "GroupMeBot",
@@ -5566,7 +7308,10 @@
       "GroupMeBot/1.0"
     ],
     "url": "https://groupme.com/",
-    "description": "GroupMe web crawler for messaging"
+    "description": "GroupMe web crawler for messaging",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Vercelbot",
@@ -5575,13 +7320,19 @@
       "Vercelbot (+https://vercel.com)"
     ],
     "url": "https://github.com/vercel/vercel/discussions/5095#discussioncomment-58705",
-    "description": "Vercel web crawler for deployment"
+    "description": "Vercel web crawler for deployment",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "vercel-screenshot",
     "addition_date": "2024/08/30",
     "instances": [],
-    "description": "Vercel screenshot web crawler bot"
+    "description": "Vercel screenshot web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "facebookcatalog\\/",
@@ -5590,7 +7341,10 @@
       "facebookcatalog/1.0"
     ],
     "url": "https://developers.facebook.com/docs/sharing/webmasters/web-crawlers",
-    "description": "Facebook catalog web crawler bot"
+    "description": "Facebook catalog web crawler bot",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "meta-externalads\\/",
@@ -5600,7 +7354,10 @@
       "meta-externalads/1.1"
     ],
     "url": "https://developers.facebook.com/docs/sharing/webmasters/web-crawlers",
-    "description": "Meta external ads web crawler bot"
+    "description": "Meta external ads web crawler bot",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "meta-externalagent\\/",
@@ -5610,7 +7367,11 @@
       "meta-externalagent/1.1"
     ],
     "url": "https://developers.facebook.com/docs/sharing/webmasters/web-crawlers",
-    "description": "Meta external agent web crawler bot"
+    "description": "Meta external agent web crawler bot",
+    "tags": [
+      "ai-crawler",
+      "social-preview"
+    ]
   },
   {
     "pattern": "meta-externalfetcher\\/",
@@ -5620,7 +7381,10 @@
       "meta-externalfetcher/1.1"
     ],
     "url": "https://developers.facebook.com/docs/sharing/webmasters/web-crawlers",
-    "description": "Meta external fetcher web crawler bot"
+    "description": "Meta external fetcher web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "AcademicBotRTU",
@@ -5629,7 +7393,10 @@
       "AcademicBotRTU (https://academicbot.rtu.lv; mailto:caps@rtu.lv)"
     ],
     "url": "https://academicbot.rtu.lv",
-    "description": "Academic Bot RTU web crawler bot"
+    "description": "Academic Bot RTU web crawler bot",
+    "tags": [
+      "academic"
+    ]
   },
   {
     "pattern": "KeybaseBot",
@@ -5638,7 +7405,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; KeybaseBot; +https://keybase.io)"
     ],
-    "description": "Keybase web crawler for link previews"
+    "description": "Keybase web crawler for link previews",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "Lemmy",
@@ -5647,7 +7417,10 @@
       "Lemmy/0.19.8; +https://leminal.space"
     ],
     "url": "https://leminal.space",
-    "description": "Lemmy social network web crawler bot"
+    "description": "Lemmy social network web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "CookieHubScan",
@@ -5656,7 +7429,10 @@
     "instances": [
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 CookieHubScan/3.0"
     ],
-    "description": "CookieHub web crawler for cookie scanning"
+    "description": "CookieHub web crawler for cookie scanning",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Hydrozen\\.io",
@@ -5665,7 +7441,10 @@
       "Hydrozen.io/1.0"
     ],
     "url": "https://docs.hydrozen.io/overview/misc/user-agent-and-ip-list",
-    "description": "Hydrozen web crawler for monitoring"
+    "description": "Hydrozen web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "HTTP Banner Detection",
@@ -5674,7 +7453,10 @@
       "HTTP Banner Detection (https://security.ipip.net)"
     ],
     "url": "https://security.ipip.net",
-    "description": "IPIP HTTP banner detection web crawler"
+    "description": "IPIP HTTP banner detection web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "SummalyBot",
@@ -5683,7 +7465,10 @@
       "SummalyBot/5.1.0"
     ],
     "url": "https://github.com/misskey-dev/summaly",
-    "description": "Summaly web crawler for content summarization"
+    "description": "Summaly web crawler for content summarization",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "MicrosoftPreview\\/",
@@ -5692,7 +7477,10 @@
     "instances": [
       "MicrosoftPreview/2.0; +https://aka.ms/MicrosoftPreview"
     ],
-    "description": "Microsoft preview web crawler bot"
+    "description": "Microsoft preview web crawler bot",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "GeedoProductSearch",
@@ -5701,7 +7489,10 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GeedoProductSearch; +http://www.geedo.com/product-search.html) Chrome/79.0.3945.88 Safari/537.36"
     ],
-    "description": "Geedo product search web crawler bot"
+    "description": "Geedo product search web crawler bot",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "TikTokSpider",
@@ -5709,7 +7500,11 @@
     "instances": [
       "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; TikTokSpider; ttspider-feedback@tiktok.com)"
     ],
-    "description": "TikTok web crawler for content discovery"
+    "description": "TikTok web crawler for content discovery",
+    "tags": [
+      "ai-crawler",
+      "social-preview"
+    ]
   },
   {
     "pattern": "OnCrawl\\/",
@@ -5719,7 +7514,10 @@
       "Mozilla/5.0 (compatible; OnCrawl/1.0; +http://www.oncrawl.com)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4 (compatible; OnCrawl/1.0; +http://www.oncrawl.com)"
     ],
-    "description": "OnCrawl SEO web crawler for analysis"
+    "description": "OnCrawl SEO web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "sindresorhus\\/got",
@@ -5728,7 +7526,10 @@
     "instances": [
       "got (https://github.com/sindresorhus/got)"
     ],
-    "description": "Got HTTP client library for requests"
+    "description": "Got HTTP client library for requests",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "CensysInspect\\/",
@@ -5737,7 +7538,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; CensysInspect/1.1; +https://about.censys.io/)"
     ],
-    "description": "Censys web crawler for security scanning"
+    "description": "Censys web crawler for security scanning",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "SBIntuitionsBot\\/",
@@ -5746,7 +7550,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; SBIntuitionsBot/0.1; +https://www.sbintuitions.co.jp/bot/)"
     ],
-    "description": "SB Intuitions web crawler bot"
+    "description": "SB Intuitions web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "sitebulb",
@@ -5755,7 +7562,10 @@
     "instances": [
       "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6439.0 Mobile Safari/537.36 +https://sitebulb.com"
     ],
-    "description": "Sitebulb SEO web crawler for analysis"
+    "description": "Sitebulb SEO web crawler for analysis",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "YextBot\\/",
@@ -5764,7 +7574,10 @@
     "instances": [
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/87.0.4280.88 YextBot/Java Safari/537.36"
     ],
-    "description": "Yext web crawler for site crawling"
+    "description": "Yext web crawler for site crawling",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "DatadogSynthetics",
@@ -5773,7 +7586,10 @@
     "instances": [
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.168 Safari/537.36 DatadogSynthetics"
     ],
-    "description": "Datadog synthetics web crawler bot"
+    "description": "Datadog synthetics web crawler bot",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Google-Ads-Conversions",
@@ -5782,14 +7598,20 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 Chrome/139.0.7258.127 Safari/537.36 Google-Ads-Conversions"
     ],
-    "description": "Google Ads conversions web crawler"
+    "description": "Google Ads conversions web crawler",
+    "tags": [
+      "advertising"
+    ]
   },
   {
     "pattern": "ObservePoint",
     "addition_date": "2025/12/23",
     "url": "https://help.observepoint.com/en/articles/9101465-allow-exclude-observepoint-traffic#h_2a8176c9b9",
     "instances": [],
-    "description": "ObservePoint web crawler for monitoring"
+    "description": "ObservePoint web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "Checkly",
@@ -5798,7 +7620,10 @@
     "instances": [
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.6998.35 Safari/537.36 (Checkly, https://www.checklyhq.com)"
     ],
-    "description": "Checkly web crawler for monitoring"
+    "description": "Checkly web crawler for monitoring",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "ALittle Client",
@@ -5807,7 +7632,10 @@
     "instances": [
       "ALittle Client"
     ],
-    "description": "ALittle web crawler for content discovery"
+    "description": "ALittle web crawler for content discovery",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "AliyunSecBot",
@@ -5816,7 +7644,10 @@
     "instances": [
       "AliyunSecBot/Aliyun AliyunSecBot@service.alibaba.com"
     ],
-    "description": "Alibaba Aliyun security web crawler bot"
+    "description": "Alibaba Aliyun security web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Claude-Web",
@@ -5825,7 +7656,10 @@
     "instances": [
       "Claude-Web/1.0 (web crawler; +https://www.anthropic.com/; bots@anthropic.com)"
     ],
-    "description": "Anthropic Claude web crawler bot"
+    "description": "Anthropic Claude web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "anthropic-ai",
@@ -5834,7 +7668,10 @@
     "instances": [
       "anthropic-ai"
     ],
-    "description": "Anthropic AI web crawler bot"
+    "description": "Anthropic AI web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "Claude-User",
@@ -5844,7 +7681,10 @@
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Claude-User/1.0; +Claude-User@anthropic.com)",
       "Claude-User (claude-code/2.1.86; +https://support.anthropic.com/)"
     ],
-    "description": "Anthropic Claude user web crawler bot"
+    "description": "Anthropic Claude user web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "Claude-SearchBot",
@@ -5853,7 +7693,11 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Claude-SearchBot/1.0; +https://www.anthropic.com)"
     ],
-    "description": "Anthropic Claude search web crawler bot"
+    "description": "Anthropic Claude search web crawler bot",
+    "tags": [
+      "ai-crawler",
+      "search-engine"
+    ]
   },
   {
     "pattern": "Google-Extended",
@@ -5862,7 +7706,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Google-Extended/1.0; +http://www.google.com/bot.html)"
     ],
-    "description": "Google extended web crawler bot"
+    "description": "Google extended web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "cohere-ai",
@@ -5871,7 +7718,10 @@
     "instances": [
       "cohere-ai"
     ],
-    "description": "Cohere AI web crawler bot"
+    "description": "Cohere AI web crawler bot",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "Timpibot",
@@ -5882,7 +7732,10 @@
       "Mozilla/5.0 (compatible; Timpibot/0.8; +http://www.timpi.io)",
       "Mozilla/5.0 (compatible; Timpibot/0.9; +http://www.timpi.io)"
     ],
-    "description": "Timpi web crawler for content discovery"
+    "description": "Timpi web crawler for content discovery",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "SERankingBacklinksBot",
@@ -5891,7 +7744,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; SERankingBacklinksBot/1.0; +https://seranking.com/backlinks-crawler)"
     ],
-    "description": "SEranking backlinks web crawler bot"
+    "description": "SEranking backlinks web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "CMSChecker",
@@ -5899,7 +7755,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; CMSChecker/1.0; +https://cmschecker.net)"
     ],
-    "description": "CMS Checker web crawler for detection"
+    "description": "CMS Checker web crawler for detection",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "Wayback",
@@ -5908,7 +7767,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; archive.org_bot; Wayback Machine Live Record; +http://archive.org/details/archive.org_bot)"
     ],
-    "description": "Internet Archive Wayback web crawler bot"
+    "description": "Internet Archive Wayback web crawler bot",
+    "tags": [
+      "archiver"
+    ]
   },
   {
     "pattern": "Playwright",
@@ -5917,7 +7779,10 @@
     "instances": [
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Playwright/1.40.0"
     ],
-    "description": "Playwright browser automation web crawler"
+    "description": "Playwright browser automation web crawler",
+    "tags": [
+      "browser-automation"
+    ]
   },
   {
     "pattern": "Puppeteer",
@@ -5926,7 +7791,10 @@
     "instances": [
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36 Puppeteer"
     ],
-    "description": "Puppeteer browser automation web crawler"
+    "description": "Puppeteer browser automation web crawler",
+    "tags": [
+      "browser-automation"
+    ]
   },
   {
     "pattern": "Selenium",
@@ -5935,7 +7803,10 @@
     "instances": [
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36; Selenium"
     ],
-    "description": "Selenium browser automation web crawler"
+    "description": "Selenium browser automation web crawler",
+    "tags": [
+      "browser-automation"
+    ]
   },
   {
     "pattern": "Nikto",
@@ -5945,7 +7816,10 @@
       "Mozilla/5.00 (Nikto/2.1.5) (Evasions:None) (Test:Port Check)",
       "Mozilla/5.0 (X11; Linux x86_64) Nikto/2.5.0 (Evasions:None) (Test:Port Check)"
     ],
-    "description": "Nikto web server security scanner bot"
+    "description": "Nikto web server security scanner bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "sqlmap",
@@ -5954,7 +7828,10 @@
     "instances": [
       "sqlmap/1.7.8#stable (https://sqlmap.org)"
     ],
-    "description": "SQLMap SQL injection testing web crawler"
+    "description": "SQLMap SQL injection testing web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "ZmEu",
@@ -5963,7 +7840,10 @@
     "instances": [
       "ZmEu"
     ],
-    "description": "ZmEu vulnerability scanner web crawler"
+    "description": "ZmEu vulnerability scanner web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "masscan",
@@ -5972,7 +7852,10 @@
     "instances": [
       "masscan/1.0 (https://github.com/robertdavidgraham/masscan)"
     ],
-    "description": "Masscan network scanner web crawler bot"
+    "description": "Masscan network scanner web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "WPScan",
@@ -5982,7 +7865,10 @@
       "WPScan v3.8.22 (https://wpscan.com/wordpress-security-scanner)",
       "Mozilla/5.0 (compatible; WPScan; +https://wpscan.com/wordpress-security-scanner)"
     ],
-    "description": "WPScan WordPress security scanner bot"
+    "description": "WPScan WordPress security scanner bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "[aA]cunetix",
@@ -5992,7 +7878,10 @@
       "Mozilla/5.0 (Windows NT 6.1; WOW64) acunetix-product/wvs (Acunetix Web Vulnerability Scanner - Free Edition)",
       "acunetix-product/wvs"
     ],
-    "description": "Acunetix web vulnerability scanner bot"
+    "description": "Acunetix web vulnerability scanner bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "Nessus",
@@ -6001,7 +7890,10 @@
     "instances": [
       "Mozilla/5.0 (compatible; Nessus; http://www.nessus.org)"
     ],
-    "description": "Nessus vulnerability scanner web crawler"
+    "description": "Nessus vulnerability scanner web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "[dD]ir[Bb]uster",
@@ -6010,7 +7902,10 @@
     "instances": [
       "DirBuster-1.0-RC1 (http://www.owasp.org/index.php/Category:OWASP_DirBuster_Project)"
     ],
-    "description": "DirBuster directory scanner web crawler"
+    "description": "DirBuster directory scanner web crawler",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "StatusCake",
@@ -6019,7 +7914,10 @@
     "instances": [
       "StatusCake_Uptime_Checker/1.0"
     ],
-    "description": "StatusCake uptime monitoring web crawler"
+    "description": "StatusCake uptime monitoring web crawler",
+    "tags": [
+      "monitoring"
+    ]
   },
   {
     "pattern": "colly",
@@ -6029,7 +7927,10 @@
       "colly - https://github.com/gocolly/colly",
       "colly/2.1.0"
     ],
-    "description": "Colly Go web crawler framework"
+    "description": "Colly Go web crawler framework",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "[mM]echanize",
@@ -6038,7 +7939,10 @@
     "instances": [
       "Mechanize/2.9.1 Ruby/3.1.2 (http://github.com/sparklemotion/mechanize/)"
     ],
-    "description": "Mechanize Ruby web crawler library"
+    "description": "Mechanize Ruby web crawler library",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "air\\.ai\\/scanning",
@@ -6046,7 +7950,10 @@
     "instances": [
       "air.ai/scanning Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/126.0.0.0 Safari/537.36"
     ],
-    "description": "Air.ai web crawler for scanning"
+    "description": "Air.ai web crawler for scanning",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "asnriskscorer",
@@ -6054,7 +7961,10 @@
     "instances": [
       "asnriskscorer/1.0"
     ],
-    "description": "ASN Risk Scorer web crawler bot"
+    "description": "ASN Risk Scorer web crawler bot",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "OICrawler",
@@ -6063,7 +7973,10 @@
     "instances": [
       "OICrawler/Nutch https://openindex.ai"
     ],
-    "description": "OpenIndex web crawler for indexing"
+    "description": "OpenIndex web crawler for indexing",
+    "tags": [
+      "search-engine"
+    ]
   },
   {
     "pattern": "l9scan",
@@ -6072,7 +7985,10 @@
     "instances": [
       "Mozilla/5.0 (l9scan/2.0; +https://github.com/LeakIX/l9scan)"
     ],
-    "description": "L9scan web crawler for scanning"
+    "description": "L9scan web crawler for scanning",
+    "tags": [
+      "scanner"
+    ]
   },
   {
     "pattern": "SlaccaleBot",
@@ -6080,7 +7996,10 @@
     "instances": [
       "SlaccaleBot"
     ],
-    "description": "Slaccale web crawler bot"
+    "description": "Slaccale web crawler bot",
+    "tags": [
+      "seo"
+    ]
   },
   {
     "pattern": "CustomAsyncHttpClient",
@@ -6088,7 +8007,10 @@
     "instances": [
       "CustomAsyncHttpClient"
     ],
-    "description": "Custom async HTTP client web crawler"
+    "description": "Custom async HTTP client web crawler",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "^HTTPie\\/",
@@ -6097,7 +8019,10 @@
     "instances": [
       "HTTPie/3.2.2"
     ],
-    "description": "HTTPie command-line HTTP client tool"
+    "description": "HTTPie command-line HTTP client tool",
+    "tags": [
+      "http-library"
+    ]
   },
   {
     "pattern": "Gemini-Deep-Research",
@@ -6106,7 +8031,11 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Gemini-Deep-Research; +https://gemini.google/overview/deep-research/) Chrome/135.0.0.0 Safari/537.36"
     ],
-    "description": "Google Gemini deep research web crawler"
+    "description": "Google Gemini deep research web crawler",
+    "tags": [
+      "ai-crawler",
+      "search-engine"
+    ]
   },
   {
     "pattern": "Perplexity-User",
@@ -6115,7 +8044,11 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Perplexity-User/1.0; +https://perplexity.ai/perplexity-user)"
     ],
-    "description": "Perplexity user web crawler bot"
+    "description": "Perplexity user web crawler bot",
+    "tags": [
+      "ai-crawler",
+      "search-engine"
+    ]
   },
   {
     "pattern": "PerplexityUser",
@@ -6124,7 +8057,11 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PerplexityUser/1.0; +https://perplexity.ai)"
     ],
-    "description": "Perplexity AI web crawler bot"
+    "description": "Perplexity AI web crawler bot",
+    "tags": [
+      "ai-crawler",
+      "search-engine"
+    ]
   },
   {
     "pattern": "meta-webindexer",
@@ -6133,7 +8070,10 @@
     "instances": [
       "meta-webindexer/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)"
     ],
-    "description": "Meta web indexer bot for Facebook and Instagram content crawling"
+    "description": "Meta web indexer bot for Facebook and Instagram content crawling",
+    "tags": [
+      "social-preview"
+    ]
   },
   {
     "pattern": "DuckAssistBot",
@@ -6142,7 +8082,11 @@
     "instances": [
       "DuckAssistBot/1.2; (+http://duckduckgo.com/duckassistbot.html)"
     ],
-    "description": "DuckDuckGo assistant bot for web crawling and search"
+    "description": "DuckDuckGo assistant bot for web crawling and search",
+    "tags": [
+      "search-engine",
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "MistralAI-User",
@@ -6150,7 +8094,10 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; MistralAI-User/1.0; +https://docs.mistral.ai/robots)"
     ],
-    "description": "Mistral AI web crawler bot for content indexing"
+    "description": "Mistral AI web crawler bot for content indexing",
+    "tags": [
+      "ai-crawler"
+    ]
   },
   {
     "pattern": "webzio",
@@ -6159,6 +8106,9 @@
     "instances": [
       "webzio (+https://webz.io/bot.html)"
     ],
-    "description": "Webz.io web crawler bot for ethical data collection"
+    "description": "Webz.io web crawler bot for ethical data collection",
+    "tags": [
+      "seo"
+    ]
   }
 ]

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -4239,7 +4239,7 @@
       "BTWebClient/180B(9704)"
     ],
     "url": "http://www.utorrent.com/",
-    "description": "\u00b5Torrent BitTorrent Client",
+    "description": "µTorrent BitTorrent Client",
     "tags": [
       "http-library"
     ]

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,8 @@
 // 	"pattern": "rogerbot",
 // 	"addition_date": "2014/02/28",
 // 	"url": "http://moz.com/help/pro/what-is-rogerbot-",
-// 	"instances" : ["rogerbot/2.3 example UA"]
+// 	"instances" : ["rogerbot/2.3 example UA"],
+// 	"tags": ["seo"]
 // }
 
 declare const crawlerUserAgents: {
@@ -11,6 +12,7 @@ declare const crawlerUserAgents: {
 	addition_date?: string
 	url?: string
 	instances: string[]
+	tags?: string[]
 }[]
 
 export = crawlerUserAgents;

--- a/validate.go
+++ b/validate.go
@@ -30,6 +30,9 @@ type Crawler struct {
 
 	// Examples of full User Agent strings.
 	Instances []string `json:"instances"`
+
+	// Classification tags (e.g. "search-engine", "ai-crawler", "seo").
+	Tags []string `json:"tags,omitempty"`
 }
 
 // Private type needed to convert addition_date from/to the format used in JSON.
@@ -38,6 +41,7 @@ type jsonCrawler struct {
 	AdditionDate string   `json:"addition_date"`
 	URL          string   `json:"url"`
 	Instances    []string `json:"instances"`
+	Tags         []string `json:"tags,omitempty"`
 }
 
 const timeLayout = "2006/01/02"
@@ -48,6 +52,7 @@ func (c Crawler) MarshalJSON() ([]byte, error) {
 		AdditionDate: c.AdditionDate.Format(timeLayout),
 		URL:          c.URL,
 		Instances:    c.Instances,
+		Tags:         c.Tags,
 	}
 	return json.Marshal(jc)
 }
@@ -61,6 +66,7 @@ func (c *Crawler) UnmarshalJSON(b []byte) error {
 	c.Pattern = jc.Pattern
 	c.URL = jc.URL
 	c.Instances = jc.Instances
+	c.Tags = jc.Tags
 
 	if c.Pattern == "" {
 		return fmt.Errorf("empty pattern in record %s", string(b))

--- a/validate.py
+++ b/validate.py
@@ -21,7 +21,8 @@ JSON_SCHEMA = {
             "url": {"type": "string"}, # optional
             "description": {"type": "string"}, # optional
             "addition_date": {"type": "string"}, # optional
-            "depends_on": {"type": "array"} # allows an instance to match twice
+            "depends_on": {"type": "array"}, # allows an instance to match twice
+            "tags": {"type": "array"} # optional, array of classification tags
         },
         "required": ["pattern", "instances"]
     }

--- a/validate.py
+++ b/validate.py
@@ -11,6 +11,21 @@ import datetime
 from jsonschema import validate
 
 
+ACCEPTED_TAGS = {
+    "search-engine",
+    "ai-crawler",
+    "social-preview",
+    "seo",
+    "monitoring",
+    "feed-reader",
+    "archiver",
+    "advertising",
+    "scanner",
+    "http-library",
+    "browser-automation",
+    "academic",
+}
+
 JSON_SCHEMA = {
     "type": "array",
     "items": {
@@ -22,7 +37,10 @@ JSON_SCHEMA = {
             "description": {"type": "string"}, # optional
             "addition_date": {"type": "string"}, # optional
             "depends_on": {"type": "array"}, # allows an instance to match twice
-            "tags": {"type": "array"} # optional, array of classification tags
+            "tags": { # optional, array of classification tags
+                "type": "array",
+                "items": {"type": "string", "enum": sorted(ACCEPTED_TAGS)},
+            }
         },
         "required": ["pattern", "instances"]
     }
@@ -67,6 +85,15 @@ def main():
     for entry in json_data:
         pattern = entry['pattern']
         
+        # check that tags, if present, only contain accepted values
+        for tag in entry.get('tags', []):
+            if tag not in ACCEPTED_TAGS:
+                raise ValueError(
+                    'Pattern {!r} has unknown tag {!r}. Accepted tags: {}'.format(
+                        pattern, tag, ', '.join(sorted(ACCEPTED_TAGS))
+                    )
+                )
+
         # assert that field "addition_date" has format "2019/12/23",
         if 'addition_date' in entry:
             if not re.match(r'\d{4}/\d{2}/\d{2}', entry['addition_date']):

--- a/validate_test.go
+++ b/validate_test.go
@@ -474,6 +474,31 @@ func contains(list []int, value int) bool {
 	return false
 }
 
+var acceptedTags = map[string]bool{
+	"search-engine":    true,
+	"ai-crawler":       true,
+	"social-preview":   true,
+	"seo":              true,
+	"monitoring":       true,
+	"feed-reader":      true,
+	"archiver":         true,
+	"advertising":      true,
+	"scanner":          true,
+	"http-library":     true,
+	"browser-automation": true,
+	"academic":         true,
+}
+
+func TestTags(t *testing.T) {
+	for _, crawler := range Crawlers {
+		for _, tag := range crawler.Tags {
+			if !acceptedTags[tag] {
+				t.Errorf("Pattern %q has unknown tag %q.", crawler.Pattern, tag)
+			}
+		}
+	}
+}
+
 func TestPatterns(t *testing.T) {
 	// Loading all crawlers with go:embed
 	// some validation happens in UnmarshalJSON.


### PR DESCRIPTION
- Add tags field to crawler-user-agents.json entries for categorization
- Implement tags support in TypeScript type definitions (index.d.ts)
- Update validation logic in Go and Python validators to handle tags field
- Update README.md example to show tags field usage
- Tags enable better classification of crawlers by type (search-engine, advertising, feed-reader, etc.)

See https://github.com/monperrus/crawler-user-agents/issues/433