### PR TITLE
Add newsai/1.0 crawler

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -8117,6 +8117,7 @@
     "url": "https://knownagents.com/agents/newsai",
     "instances": [
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 newsai/1.0 Safari/537.36"
-    ]
+    ],
+    "description": "NewsAI crawler for news content aggregation and indexing"
   }
 ]

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -8110,5 +8110,13 @@
     "tags": [
       "seo"
     ]
+  },
+  {
+    "pattern": "newsai\\/",
+    "addition_date": "2026/04/14",
+    "url": "https://knownagents.com/agents/newsai",
+    "instances": [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 newsai/1.0 Safari/537.36"
+    ]
   }
 ]


### PR DESCRIPTION
Adds detection for the newsai/1.0 user agent, observed in production traffic. The bot masquerades as a standard Chrome user agent and injects the newsai/1.0 token mid-string, e.g.:
`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 newsai/1.0 Safari/537.36`
The operator is currently unknown; the agent is tracked as uncategorized on knownagents.com (formerly Dark Visitors), linked as the reference URL.
Pattern newsai\/ is chosen to be discriminant without locking to a specific version.