### PR TITLE
Fix Segmentation fault Error in Python 3.14 when running validate.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
   "pluggy==1.5.0",
   "pytest==8.2.0",
   "referencing==0.35.0",
-  "rpds-py==0.18.0",
+  "rpds-py==0.25.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Bumps rpds-py from 0.18.0 to 0.25.0, in this version a wheel becomes available so jsonschema doesn't segfault anymore.

The original error is `Segmentation fault         (core dumped) python validate.py`.