### PR TITLE
Add tags field to NewsAI/1.0 crawler entry

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -8118,6 +8118,10 @@
     "instances": [
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 newsai/1.0 Safari/537.36"
     ],
-    "description": "NewsAI crawler for news content aggregation and indexing"
+    "description": "NewsAI crawler for news content aggregation and indexing",
+    "tags": [
+      "ai-crawler",
+      "feed-reader"
+    ]
   }
 ]


### PR DESCRIPTION
added tags "ai-crawler" and "feed-reader" for categorization see https://github.com/monperrus/crawler-user-agents/issues/433 and https://github.com/monperrus/crawler-user-agents/pull/435