### PR TITLE
Add watchTowr scanner

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -8123,5 +8123,17 @@
       "ai-crawler",
       "feed-reader"
     ]
+  },
+  {
+    "pattern": "watchTowr",
+    "addition_date": "2026/04/23",
+    "url": "https://watchtowr.com",
+    "instances": [
+      "Mozilla/5.0 (watchTowr; Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0"
+    ],
+    "description": "watchTowr is an external attack surface management tool that scans assets and generates findings against those assets",
+    "tags": [
+      "scanner"
+    ]
   }
 ]

--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -18339,5 +18339,17 @@
     "tags": [
       "feed-reader"
     ]
+  },
+  {
+    "pattern": "watchTowr",
+    "addition_date": "2026/04/23",
+    "url": "https://watchtowr.com",
+    "instances": [
+      "Mozilla/5.0 (watchTowr; Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0"
+    ],
+    "description": "watchTowr is an external attack surface management tool that scans assets and generates findings against those assets",
+    "tags": [
+      "scanner"
+    ]
   }
 ]


### PR DESCRIPTION
Adds detection for the watchTowr user agent.
The bot masquerades as a standard Mozilla user agent and injects the watchTowr mid-string, e.g.: Mozilla/5.0 (watchTowr; Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0
The operator seems https://watchtowr.com.
Pattern watchtowr is chosen to be discriminant without locking to a specific version.