### PR TITLE
Add clf-filter binary and release workflow

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,25 @@
+# Build a statically linked clf-filter binary and attach it to the GitHub release for each tag.
+
+name: Release binary
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release-binary:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build static binary
+        run: CGO_ENABLED=0 go build -ldflags="-w -s" -o clf-filter ./cmd/clf-filter/
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: clf-filter

--- a/cmd/clf-filter/main.go
+++ b/cmd/clf-filter/main.go
@@ -1,0 +1,51 @@
+// clf-filter reads Combined Log Format lines from stdin and writes them to stdout,
+// removing bot/crawler lines by default. Use --bot to keep only bot lines.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	agents "github.com/monperrus/crawler-user-agents"
+)
+
+func extractUserAgent(line string) (string, bool) {
+	// Combined Log Format ends with: "referer" "user-agent"
+	// Find the last quoted field.
+	end := strings.LastIndex(line, "\"")
+	if end < 1 {
+		return "", false
+	}
+	start := strings.LastIndex(line[:end], "\"")
+	if start < 0 {
+		return "", false
+	}
+	return line[start+1 : end], true
+}
+
+func main() {
+	botOnly := flag.Bool("bot", false, "keep only bot/crawler lines (default: remove bots)")
+	flag.Parse()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	// Support long lines (e.g. large URLs).
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		ua, ok := extractUserAgent(line)
+		isBot := ok && agents.IsCrawler(ua)
+
+		if *botOnly == isBot {
+			fmt.Println(line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintln(os.Stderr, "clf-filter: read error:", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cmd/clf-filter/main.go`: a Go program that reads Combined Log Format lines from stdin and filters by bot/crawler User-Agent — removes bots by default, or keeps only bots with `--bot`
- Adds `.github/workflows/release-binary.yml`: builds a statically linked binary (`CGO_ENABLED=0`) on each `v*` tag push and uploads it to the corresponding GitHub release

## Usage

```sh
# Remove bot lines from an access log
cat access.log | clf-filter > human-only.log

# Keep only bot lines
cat access.log | clf-filter --bot > bots-only.log
```

## Test plan

- [ ] CI validation passes
- [ ] After merge, verify the release workflow attaches `clf-filter` to the next tag's release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)