### PR TITLE
fix: anchor Silk pattern to avoid false positive on Amazon Silk browser

### DIFF
--- a/crawler-user-agents.json
+++ b/crawler-user-agents.json
@@ -16777,7 +16777,7 @@
     ]
   },
   {
-    "pattern": "Silk\\/",
+    "pattern": "^Silk\\/",
     "url": "https://www.useragentstring.com/pages/silk/",
     "instances": [
       "Silk/1.0 Also seen as: silk/1.0 (+http://www.slider.com/silk.htm)/3.7"


### PR DESCRIPTION
## Summary

- The `Silk\/` pattern was matching Amazon Silk browser user agents (e.g. `Mozilla/5.0 ... Silk/138.x like Chrome/...`)
- The actual Silk crawler UA starts with `Silk/`, so anchoring with `^` fixes the false positive without affecting crawler detection

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)